### PR TITLE
Errno.t: "no strict 'refs';" needed in one location

### DIFF
--- a/ext/Errno/t/Errno.t
+++ b/ext/Errno/t/Errno.t
@@ -12,9 +12,12 @@ BEGIN {
 BAIL_OUT("No errno's are exported") unless @Errno::EXPORT_OK;
 
 my $err = $Errno::EXPORT_OK[0];
-my $num = &{"Errno::$err"};
-
-is($num, &{"Errno::$err"});
+my $num;
+{
+    no strict 'refs';
+    my $num = &{"Errno::$err"};
+    is($num, &{"Errno::$err"});
+}
 
 $! = $num;
 ok(exists $!{$err});


### PR DESCRIPTION
For: https://github.com/atoomic/perl/issues/61