### PR TITLE
Ops 20200712

### DIFF
--- a/t/op/args.t
+++ b/t/op/args.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('../lib');
 }
 
-plan( tests => 23 );
+plan( tests => 24 );
 
 # test various operations on @_
 
@@ -72,9 +72,15 @@ my $foo = 'foo'; local1($foo); local1($foo);
 is($foo, 'foo',
     "got 'foo' as expected rather than '\$foo': RT \#21542");
 
-sub local2 { local $_[0]; last L }
-L: { local2 }
-pass("last to label");
+{
+    my @these_warnings = ();
+    local $SIG{__WARN__} = sub { push @these_warnings, $_[0]; };
+    sub local2 { local $_[0]; last L }
+    L: { local2 }
+    pass("last to label");
+    like($these_warnings[0], qr/Exiting subroutine via last/,
+        "Got expected warning: exiting sub via last");
+}
 
 # the following test for local(@_) used to be in t/op/nothr5005.t (because it
 # failed with 5005threads)

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -27,8 +27,11 @@ $foo[0] = '0';
 $r = join(',', $#foo, @foo);
 is($r, "0,0");
 $foo[2] = '2';
-$r = join(',', $#foo, @foo);
-is($r, "2,0,,2");
+{
+    no warnings 'uninitialized';
+    $r = join(',', $#foo, @foo);
+    is($r, "2,0,,2");
+}
 my @bar = ();
 $bar[0] = '0';
 $bar[1] = '1';
@@ -41,16 +44,22 @@ $bar[0] = '0';
 $r = join(',', $#bar, @bar);
 is($r, "0,0");
 $bar[2] = '2';
-$r = join(',', $#bar, @bar);
-is($r, "2,0,,2");
+{
+    no warnings 'uninitialized';
+    $r = join(',', $#bar, @bar);
+    is($r, "2,0,,2");
+}
 reset 'b' if $^O ne 'VMS';
 @bar = ();
 $bar[0] = '0';
 $r = join(',', $#bar, @bar);
 is($r, "0,0");
 $bar[2] = '2';
-$r = join(',', $#bar, @bar);
-is($r, "2,0,,2");
+{
+    no warnings 'uninitialized';
+    $r = join(',', $#bar, @bar);
+    is($r, "2,0,,2");
+}
 
 my $foo = 'now is the time';
 my ($F1,$F2,$Etc);
@@ -88,8 +97,11 @@ is($foo, 'abcdef');
 $foo = join('',('a','b','c','d','e','f')[0..1]);
 is($foo, 'ab');
 
-$foo = join('',('a','b','c','d','e','f')[6]);
-is($foo, '');
+{
+    no warnings 'uninitialized';
+    $foo = join('',('a','b','c','d','e','f')[6]);
+    is($foo, '');
+}
 
 @foo = ('a','b','c','d','e','f')[0,2,4];
 @bar = ('a','b','c','d','e','f')[1,3,5];

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -144,7 +144,7 @@ is($foo, 'b');
 # XXX tie-stdarray fails the tests involving local, so we use
 # different variable names to escape the 'tie'
 
-no strict;
+no strict 'vars';
 @bee = ( 'foo', 'bar', 'burbl', 'blah');
 {
     no warnings;
@@ -366,28 +366,38 @@ sub test_arylen {
 {
     # Bug #37350
     my @array = (1..4);
+    no strict 'refs';
     $#{@array} = 7;
+    use strict 'refs';
     is ($#{4}, 7);
 
     my $x;
     $#{$x} = 3;
     is(scalar @$x, 4);
 
+    no strict 'refs';
     push @{@array}, 23;
+    use strict 'refs';
     is ($4[8], 23);
 }
 {
     # Bug #37350 -- once more with a global
     use vars '@array';
     @array = (1..4);
+    no strict 'refs';
     $#{@array} = 7;
+    use strict 'refs';
     is ($#{4}, 7);
 
     my $x;
+    no strict 'refs';
     $#{$x} = 3;
+    use strict 'refs';
     is(scalar @$x, 4);
 
+    no strict 'refs';
     push @{@array}, 23;
+    use strict 'refs';
     is ($4[8], 23);
 }
 
@@ -427,6 +437,7 @@ sub test_arylen {
 
 # [perl #70171], [perl #82110]
 {
+    no strict 'refs';
     my ($i, $ra, $rh);
   again:
     my @a = @$ra; # common assignment on 2nd attempt
@@ -709,6 +720,7 @@ $#a = -1; $#a++;
     is "[@a]", "[7 3 1]",
        'holes passed to sub do not lose their position (aelem, mg)';
 }
+use strict;
 
 no warnings 'void';
 "We're included by lib/Tie/Array/std.t so we need to return something true";

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -440,8 +440,10 @@ sub test_arylen {
     no strict 'refs';
     my ($i, $ra, $rh);
   again:
+    no warnings 'uninitialized';
     my @a = @$ra; # common assignment on 2nd attempt
     my %h = %$rh; # common assignment on 2nd attempt
+    use warnings 'uninitialized';
     @a = qw(1 2 3 4);
     %h = qw(a 1 b 2 c 3 d 4);
     $ra = \@a;

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -682,8 +682,11 @@ $#a = -1; $#a++;
     delete $a[0];
     @a[1..5] = 1..5;
     $#a++;
-    my $count;
-    my @existing_elements = map { exists $a[$count++] ? $_ : () } @a;
+
+    undef $count;
+    undef @existing_elements;
+    @existing_elements = map { exists $a[$count++] ? $_ : () } @a;
+    use warnings 'shadow';
     is join(",", @existing_elements), "1,2,3,4,5",
        'map {} @a does not vivify elements';
     $#a = -1;

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -458,7 +458,13 @@ sub test_arylen {
 }
 
 
-*trit = *scile;  $trit[0];
+{
+    no warnings 'once';
+    *trit = *scile;
+    use warnings 'once';
+    no warnings 'void';
+    $trit[0];
+}
 ok(1, 'aelem_fast on a nonexistent array does not crash');
 
 # [perl #107440]

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -6,7 +6,7 @@ BEGIN {
     set_up_inc('.', '../lib');
 }
 
-plan (195);
+plan (197);
 
 #
 # @foo, @bar, and @ary are also used from tie-stdarray after tie-ing them
@@ -342,12 +342,22 @@ sub test_arylen {
     is (scalar @array, 7);
     is ($$outer, 6);
 
-    $$inner = 1;
+    {
+        my @warn;
+        local $SIG{__WARN__} = sub {push @warn, "@_"};
+        $$inner = 1;
+        like ($warn[0], qr/^Attempt to set length of freed array/);
+    }
 
     is (scalar @array, 7);
     is ($$outer, 6);
 
-    $$inner = 503; # Bang!
+    {
+        my @warn;
+        local $SIG{__WARN__} = sub {push @warn, "@_"};
+        $$inner = 503; # Bang!
+        like ($warn[0], qr/^Attempt to set length of freed array/);
+    }
 
     is (scalar @array, 7);
     is ($$outer, 6);

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -144,502 +144,510 @@ is($foo, 'b');
 # XXX tie-stdarray fails the tests involving local, so we use
 # different variable names to escape the 'tie'
 
-no strict 'vars';
-@bee = ( 'foo', 'bar', 'burbl', 'blah');
 {
-    no warnings;
-    local @bee = @bee;
-    is("@bee", "foo bar burbl blah");				# 43
+    # An immense swaths of tests in this file will not pass with strict vars
+    no strict 'vars';
+    @bee = ( 'foo', 'bar', 'burbl', 'blah');
     {
-	local (undef,@bee) = @bee;
-	is("@bee", "bar burbl blah");				# 44
-	{
-	    local @bee = ('XXX',@bee,'YYY');
-	    is("@bee", "XXX bar burbl blah YYY");		# 45
-	    {
-		local @bee = local(@bee) = qw(foo bar burbl blah);
-		is("@bee", "foo bar burbl blah");		# 46
-		{
-		    local (@bim) = local(@bee) = qw(foo bar);
-		    is("@bee", "foo bar");			# 47
-		    is("@bim", "foo bar");			# 48
-		}
-		is("@bee", "foo bar burbl blah");		# 49
-	    }
-	    is("@bee", "XXX bar burbl blah YYY");		# 50
-	}
-	is("@bee", "bar burbl blah");				# 51
-    }
-    is("@bee", "foo bar burbl blah");				# 52
-}
-
-# try the same with my
-{
-    my @bee = @bee;
-    is("@bee", "foo bar burbl blah");				# 53
-    {
-	my (undef,@bee) = @bee;
-	is("@bee", "bar burbl blah");				# 54
-	{
-	    my @bee = ('XXX',@bee,'YYY');
-	    is("@bee", "XXX bar burbl blah YYY");		# 55
-	    {
-		my @bee = my @bee = qw(foo bar burbl blah);
-		is("@bee", "foo bar burbl blah");		# 56
-		{
-		    my (@bim) = my(@bee) = qw(foo bar);
-		    is("@bee", "foo bar");			# 57
-		    is("@bim", "foo bar");			# 58
-		}
-		is("@bee", "foo bar burbl blah");		# 59
-	    }
-	    is("@bee", "XXX bar burbl blah YYY");		# 60
-	}
-	is("@bee", "bar burbl blah");				# 61
-    }
-    is("@bee", "foo bar burbl blah");				# 62
-}
-
-# try the same with our (except that previous values aren't restored)
-{
-    our @bee = @bee;
-    is("@bee", "foo bar burbl blah");
-    {
-	our (undef,@bee) = @bee;
-	is("@bee", "bar burbl blah");
-	{
-	    our @bee = ('XXX',@bee,'YYY');
-	    is("@bee", "XXX bar burbl blah YYY");
-	    {
-		our @bee = our @bee = qw(foo bar burbl blah);
-		is("@bee", "foo bar burbl blah");
-		{
-		    our (@bim) = our(@bee) = qw(foo bar);
-		    is("@bee", "foo bar");
-		    is("@bim", "foo bar");
-		}
-	    }
-	}
-    }
-}
-
-# make sure reification behaves
-my $t = curr_test();
-sub reify { $_[1] = $t++; print "@_\n"; }
-reify('ok');
-reify('ok');
-
-curr_test($t);
-
-# qw() is no longer a runtime split, it's compiletime.
-is (qw(foo bar snorfle)[2], 'snorfle');
-
-@ary = (12,23,34,45,56);
-
-is(shift(@ary), 12);
-is(pop(@ary), 56);
-is(push(@ary,56), 4);
-is(unshift(@ary,12), 5);
-
-sub foo { "a" }
-@foo=(foo())[0,0];
-is ($foo[1], "a");
-
-# bugid #15439 - clearing an array calls destructors which may try
-# to modify the array - caused 'Attempt to free unreferenced scalar'
-
-my $got = runperl (
-	prog => q{
-		    sub X::DESTROY { @a = () }
-		    @a = (bless {}, q{X});
-		    @a = ();
-		},
-	stderr => 1,
-    run_as_five => 1,
-    );
-
-$got =~ s/\n/ /g;
-is ($got, '');
-
-# Test negative and funky indices.
-
-
-{
-    my @a = 0..4;
-    is($a[-1], 4);
-    is($a[-2], 3);
-    is($a[-5], 0);
-    ok(!defined $a[-6]);
-
-    is($a[2.1]  , 2);
-    is($a[2.9]  , 2);
-    no warnings 'uninitialized';
-    is($a[undef], 0);
-    no warnings 'numeric';
-    is($a["3rd"], 3);
-}
-
-
-{
-    my @a;
-    eval '$a[-1] = 0';
-    like($@, qr/Modification of non-creatable array value attempted, subscript -1/, "\$a[-1] = 0");
-}
-
-sub test_arylen {
-    my $ref = shift;
-    local $^W = 1;
-    is ($$ref, undef, "\$# on freed array is undef");
-    my @warn;
-    local $SIG{__WARN__} = sub {push @warn, "@_"};
-    $$ref = 1000;
-    is (scalar @warn, 1);
-    like ($warn[0], qr/^Attempt to set length of freed array/);
-}
-
-{
-    my $a = \$#{[]};
-    # Need a new statement to make it go out of scope
-    test_arylen ($a);
-    test_arylen (do {my @a; \$#a});
-}
-
-{
-    use vars '@array';
-
-    my $outer = \$#array;
-    is ($$outer, -1);
-    is (scalar @array, 0);
-
-    $$outer = 3;
-    is ($$outer, 3);
-    is (scalar @array, 4);
-
-    my $ref = \@array;
-
-    my $inner;
-    {
-	local @array;
-	$inner = \$#array;
-
-	is ($$inner, -1);
-	is (scalar @array, 0);
-	$$outer = 6;
-
-	is (scalar @$ref, 7);
-
-	is ($$inner, -1);
-	is (scalar @array, 0);
-
-	$$inner = 42;
+        no warnings;
+        local @bee = @bee;
+        is("@bee", "foo bar burbl blah");                   # 43
+        {
+            local (undef,@bee) = @bee;
+            is("@bee", "bar burbl blah");                   # 44
+            {
+                local @bee = ('XXX',@bee,'YYY');
+                is("@bee", "XXX bar burbl blah YYY");       # 45
+                {
+                    local @bee = local(@bee) = qw(foo bar burbl blah);
+                    is("@bee", "foo bar burbl blah");       # 46
+                    {
+                        local (@bim) = local(@bee) = qw(foo bar);
+                        is("@bee", "foo bar");              # 47
+                        is("@bim", "foo bar");              # 48
+                    }
+                    is("@bee", "foo bar burbl blah");       # 49
+                }
+                is("@bee", "XXX bar burbl blah YYY");       # 50
+            }
+            is("@bee", "bar burbl blah");                   # 51
+        }
+        is("@bee", "foo bar burbl blah");                   # 52
     }
 
-    is (scalar @array, 7);
-    is ($$outer, 6);
+    # try the same with my
+    {
+        my @bee = @bee;
+        is("@bee", "foo bar burbl blah");                   # 53
+        {
+            my (undef,@bee) = @bee;
+            is("@bee", "bar burbl blah");                   # 54
+            {
+                my @bee = ('XXX',@bee,'YYY');
+                is("@bee", "XXX bar burbl blah YYY");       # 55
+                {
+                    no warnings 'shadow';
+                    my @bee = my @bee = qw(foo bar burbl blah);
+                    is("@bee", "foo bar burbl blah");       # 56
+                    use warnings 'shadow';
+                    {
+                        my (@bim) = my(@bee) = qw(foo bar);
+                        is("@bee", "foo bar");              # 57
+                        is("@bim", "foo bar");              # 58
+                    }
+                    is("@bee", "foo bar burbl blah");       # 59
+                }
+                is("@bee", "XXX bar burbl blah YYY");       # 60
+            }
+            is("@bee", "bar burbl blah");                   # 61
+        }
+        is("@bee", "foo bar burbl blah");                   # 62
+    }
 
-    is ($$inner, undef, "orphaned $#foo is always undef");
+    # try the same with our (except that previous values aren't restored)
+    {
+        our @bee = @bee;
+        is("@bee", "foo bar burbl blah");
+        {
+            no warnings 'shadow';
+            # "our" variable @bee redeclared
+            our (undef,@bee) = @bee;
+            is("@bee", "bar burbl blah");
+            {
+                our @bee = ('XXX',@bee,'YYY');
+                is("@bee", "XXX bar burbl blah YYY");
+                {
+                    our @bee = our @bee = qw(foo bar burbl blah);
+                    is("@bee", "foo bar burbl blah");
+                    {
+                        our (@bim) = our(@bee) = qw(foo bar);
+                        is("@bee", "foo bar");
+                        is("@bim", "foo bar");
+                    }
+                }
+            }
+        }
+    }
 
-    is (scalar @array, 7);
-    is ($$outer, 6);
+    # make sure reification behaves
+    my $t = curr_test();
+    sub reify { $_[1] = $t++; print "@_\n"; }
+    reify('ok');
+    reify('ok');
+
+    curr_test($t);
+
+    # qw() is no longer a runtime split, it's compiletime.
+    is (qw(foo bar snorfle)[2], 'snorfle');
+
+    @ary = (12,23,34,45,56);
+
+    is(shift(@ary), 12);
+    is(pop(@ary), 56);
+    is(push(@ary,56), 4);
+    is(unshift(@ary,12), 5);
+
+    sub foo { "a" }
+    @foo=(foo())[0,0];
+    is ($foo[1], "a");
+
+    # bugid #15439 - clearing an array calls destructors which may try
+    # to modify the array - caused 'Attempt to free unreferenced scalar'
+
+    my $got = runperl (
+        prog => q{
+                sub X::DESTROY { @a = () }
+                @a = (bless {}, q{X});
+                @a = ();
+            },
+        stderr => 1,
+        run_as_five => 1,
+        );
+
+    $got =~ s/\n/ /g;
+    is ($got, '');
+
+    # Test negative and funky indices.
+
 
     {
+        my @a = 0..4;
+        is($a[-1], 4);
+        is($a[-2], 3);
+        is($a[-5], 0);
+        ok(!defined $a[-6]);
+
+        is($a[2.1]  , 2);
+        is($a[2.9]  , 2);
+        no warnings 'uninitialized';
+        is($a[undef], 0);
+        no warnings 'numeric';
+        is($a["3rd"], 3);
+    }
+
+
+    {
+        my @a;
+        eval '$a[-1] = 0';
+        like($@, qr/Modification of non-creatable array value attempted, subscript -1/, "\$a[-1] = 0");
+    }
+
+    sub test_arylen {
+        my $ref = shift;
+        local $^W = 1;
+        is ($$ref, undef, "\$# on freed array is undef");
         my @warn;
         local $SIG{__WARN__} = sub {push @warn, "@_"};
-        $$inner = 1;
+        $$ref = 1000;
+        is (scalar @warn, 1);
         like ($warn[0], qr/^Attempt to set length of freed array/);
     }
 
-    is (scalar @array, 7);
-    is ($$outer, 6);
+    {
+        my $a = \$#{[]};
+        # Need a new statement to make it go out of scope
+        test_arylen ($a);
+        test_arylen (do {my @a; \$#a});
+    }
 
+    {
+        use vars '@array';
+
+        my $outer = \$#array;
+        is ($$outer, -1);
+        is (scalar @array, 0);
+
+        $$outer = 3;
+        is ($$outer, 3);
+        is (scalar @array, 4);
+
+        my $ref = \@array;
+
+        my $inner;
+        {
+        local @array;
+        $inner = \$#array;
+
+        is ($$inner, -1);
+        is (scalar @array, 0);
+        $$outer = 6;
+
+        is (scalar @$ref, 7);
+
+        is ($$inner, -1);
+        is (scalar @array, 0);
+
+        $$inner = 42;
+        }
+
+        is (scalar @array, 7);
+        is ($$outer, 6);
+
+        is ($$inner, undef, "orphaned $#foo is always undef");
+
+        is (scalar @array, 7);
+        is ($$outer, 6);
+
+        {
+            my @warn;
+            local $SIG{__WARN__} = sub {push @warn, "@_"};
+            $$inner = 1;
+            like ($warn[0], qr/^Attempt to set length of freed array/);
+        }
+
+        is (scalar @array, 7);
+        is ($$outer, 6);
+
+        {
+            my @warn;
+            local $SIG{__WARN__} = sub {push @warn, "@_"};
+            $$inner = 503; # Bang!
+            like ($warn[0], qr/^Attempt to set length of freed array/);
+        }
+
+        is (scalar @array, 7);
+        is ($$outer, 6);
+    }
+
+    {
+        # Bug #36211
+        use vars '@array';
+        for (1,2) {
+        {
+            local @a;
+            is ($#a, -1);
+            @a=(1..4)
+        }
+        }
+    }
+
+    {
+        # Bug #37350
+        my @array = (1..4);
+        no strict 'refs';
+        $#{@array} = 7;
+        use strict 'refs';
+        is ($#{4}, 7);
+
+        my $x;
+        $#{$x} = 3;
+        is(scalar @$x, 4);
+
+        no strict 'refs';
+        push @{@array}, 23;
+        use strict 'refs';
+        is ($4[8], 23);
+    }
+    {
+        # Bug #37350 -- once more with a global
+        use vars '@array';
+        @array = (1..4);
+        no strict 'refs';
+        $#{@array} = 7;
+        use strict 'refs';
+        is ($#{4}, 7);
+
+        my $x;
+        no strict 'refs';
+        $#{$x} = 3;
+        use strict 'refs';
+        is(scalar @$x, 4);
+
+        no strict 'refs';
+        push @{@array}, 23;
+        use strict 'refs';
+        is ($4[8], 23);
+    }
+
+    # more tests for AASSIGN_COMMON
+
+    {
+        our($x,$y,$z) = (1..3);
+        no warnings 'shadow';
+        our($y,$z) = ($x,$y);
+        is("$x $y $z", "1 1 2");
+    }
+    {
+        our($x,$y,$z) = (1..3);
+        no warnings 'shadow';
+        (our $y, our $z) = ($x,$y);
+        is("$x $y $z", "1 1 2");
+    }
+    {
+        # AASSIGN_COMMON detection with logical operators
+        my $true = 1;
+        our($x,$y,$z) = (1..3);
+        no warnings 'shadow';
+        (our $y, our $z) = $true && ($x,$y);
+        is("$x $y $z", "1 1 2");
+    }
+
+    # [perl #70171]
+    {
+     my $x = get_x(); my %x = %$x; sub get_x { %x=(1..4); return \%x };
+     is(
+       join(" ", map +($_,$x{$_}), sort keys %x), "1 2 3 4",
+      'bug 70171 (self-assignment via my %x = %$x)'
+     );
+     my $y = get_y(); my @y = @$y; sub get_y { @y=(1..4); return \@y };
+     is(
+      "@y", "1 2 3 4",
+      'bug 70171 (self-assignment via my @x = @$x)'
+     );
+    }
+
+    # [perl #70171], [perl #82110]
+    {
+        no strict 'refs';
+        my ($i, $ra, $rh);
+      again:
+        no warnings 'uninitialized';
+        my @a = @$ra; # common assignment on 2nd attempt
+        my %h = %$rh; # common assignment on 2nd attempt
+        use warnings 'uninitialized';
+        @a = qw(1 2 3 4);
+        %h = qw(a 1 b 2 c 3 d 4);
+        $ra = \@a;
+        $rh = \%h;
+        goto again unless $i++;
+
+        is("@a", "1 2 3 4",
+        'bug 70171 (self-assignment via my @x = @$x) - goto variant'
+        );
+        is(
+        join(" ", map +($_,$h{$_}), sort keys %h), "a 1 b 2 c 3 d 4",
+        'bug 70171 (self-assignment via my %x = %$x) - goto variant'
+        );
+    }
+
+
+    {
+        no warnings 'once';
+        *trit = *scile;
+        use warnings 'once';
+        no warnings 'void';
+        $trit[0];
+    }
+    ok(1, 'aelem_fast on a nonexistent array does not crash');
+
+    # [perl #107440]
+    sub A::DESTROY { $::ra = 0 }
+    $::ra = [ bless [], 'A' ];
+    undef @$::ra;
+    pass 'no crash when freeing array that is being undeffed';
+    $::ra = [ bless [], 'A' ];
+    @$::ra = ('a'..'z');
+    pass 'no crash when freeing array that is being cleared';
+
+    # [perl #85670] Copying magic to elements
+    SKIP: {
+        skip "no Scalar::Util::weaken on miniperl", 1, if is_miniperl;
+        require Scalar::Util;
+        package glelp {
+        Scalar::Util::weaken ($a = \@ISA);
+        @ISA = qw(Foo);
+        Scalar::Util::weaken ($a = \$ISA[0]);
+        ::is @ISA, 1, 'backref magic is not copied to elements';
+        }
+    }
+    package peen {
+        $#ISA = -1;
+        @ISA = qw(Foo);
+        $ISA[0] = qw(Sphare);
+
+        sub Sphare::pling { 'pling' }
+
+        ::is eval { peen->pling }, 'pling',
+        'arylen_p magic does not stop isa magic from being copied';
+    }
+
+    # Test that &PL_sv_undef is not special in arrays
+    sub {
+        ok exists $_[0],
+          'exists returns true for &PL_sv_undef elem [perl #7508]';
+        is \$_[0], \undef, 'undef preserves identity in array [perl #109726]';
+    }->(undef);
+    # and that padav also knows how to handle the resulting NULLs
+    @_ = sub { my @a; $a[1]=1; @a }->();
+    is join (" ", map $_//"undef", @_), "undef 1",
+      'returning my @a with nonexistent elements';
+
+    # [perl #118691]
+    @plink=@plunk=();
+    $plink[3] = 1;
+    sub {
+        $_[0] = 2;
+        is $plink[0], 2, '@_ alias to nonexistent elem within array';
+        $_[1] = 3;
+        is $plink[1], 3, '@_ alias to nonexistent neg index within array';
+        is $_[2], undef, 'reading alias to negative index past beginning';
+        eval { $_[2] = 42 };
+        like $@, qr/Modification of non-creatable array value attempted, (?x:
+                   )subscript -5/,
+             'error when setting alias to negative index past beginning';
+        is $_[3], undef, 'reading alias to -1 elem of empty array';
+        eval { $_[3] = 42 };
+        like $@, qr/Modification of non-creatable array value attempted, (?x:
+                   )subscript -1/,
+             'error when setting alias to -1 elem of empty array';
+    }->($plink[0], $plink[-2], $plink[-5], $plunk[-1]);
+
+    $_ = \$#{[]};
     {
         my @warn;
         local $SIG{__WARN__} = sub {push @warn, "@_"};
-        $$inner = 503; # Bang!
+        $$_ = \1;
         like ($warn[0], qr/^Attempt to set length of freed array/);
     }
-
-    is (scalar @array, 7);
-    is ($$outer, 6);
-}
-
-{
-    # Bug #36211
-    use vars '@array';
-    for (1,2) {
-	{
-	    local @a;
-	    is ($#a, -1);
-	    @a=(1..4)
-	}
+    {
+        no warnings 'void';
+        no warnings 'uninitialized';
+        "$$_";
     }
-}
-
-{
-    # Bug #37350
-    my @array = (1..4);
-    no strict 'refs';
-    $#{@array} = 7;
-    use strict 'refs';
-    is ($#{4}, 7);
-
-    my $x;
-    $#{$x} = 3;
-    is(scalar @$x, 4);
-
-    no strict 'refs';
-    push @{@array}, 23;
-    use strict 'refs';
-    is ($4[8], 23);
-}
-{
-    # Bug #37350 -- once more with a global
-    use vars '@array';
-    @array = (1..4);
-    no strict 'refs';
-    $#{@array} = 7;
-    use strict 'refs';
-    is ($#{4}, 7);
-
-    my $x;
-    no strict 'refs';
-    $#{$x} = 3;
-    use strict 'refs';
-    is(scalar @$x, 4);
-
-    no strict 'refs';
-    push @{@array}, 23;
-    use strict 'refs';
-    is ($4[8], 23);
-}
-
-# more tests for AASSIGN_COMMON
-
-{
-    our($x,$y,$z) = (1..3);
-    no warnings 'shadow';
-    our($y,$z) = ($x,$y);
-    is("$x $y $z", "1 1 2");
-}
-{
-    our($x,$y,$z) = (1..3);
-    no warnings 'shadow';
-    (our $y, our $z) = ($x,$y);
-    is("$x $y $z", "1 1 2");
-}
-{
-    # AASSIGN_COMMON detection with logical operators
-    my $true = 1;
-    our($x,$y,$z) = (1..3);
-    no warnings 'shadow';
-    (our $y, our $z) = $true && ($x,$y);
-    is("$x $y $z", "1 1 2");
-}
-
-# [perl #70171]
-{
- my $x = get_x(); my %x = %$x; sub get_x { %x=(1..4); return \%x };
- is(
-   join(" ", map +($_,$x{$_}), sort keys %x), "1 2 3 4",
-  'bug 70171 (self-assignment via my %x = %$x)'
- );
- my $y = get_y(); my @y = @$y; sub get_y { @y=(1..4); return \@y };
- is(
-  "@y", "1 2 3 4",
-  'bug 70171 (self-assignment via my @x = @$x)'
- );
-}
-
-# [perl #70171], [perl #82110]
-{
-    no strict 'refs';
-    my ($i, $ra, $rh);
-  again:
-    no warnings 'uninitialized';
-    my @a = @$ra; # common assignment on 2nd attempt
-    my %h = %$rh; # common assignment on 2nd attempt
-    use warnings 'uninitialized';
-    @a = qw(1 2 3 4);
-    %h = qw(a 1 b 2 c 3 d 4);
-    $ra = \@a;
-    $rh = \%h;
-    goto again unless $i++;
-
-    is("@a", "1 2 3 4",
-	'bug 70171 (self-assignment via my @x = @$x) - goto variant'
-    );
-    is(
-	join(" ", map +($_,$h{$_}), sort keys %h), "a 1 b 2 c 3 d 4",
-	'bug 70171 (self-assignment via my %x = %$x) - goto variant'
-    );
-}
+    pass "no assertion failure after assigning ref to arylen when ary is gone";
 
 
-{
-    no warnings 'once';
-    *trit = *scile;
-    use warnings 'once';
-    no warnings 'void';
-    $trit[0];
-}
-ok(1, 'aelem_fast on a nonexistent array does not crash');
-
-# [perl #107440]
-sub A::DESTROY { $::ra = 0 }
-$::ra = [ bless [], 'A' ];
-undef @$::ra;
-pass 'no crash when freeing array that is being undeffed';
-$::ra = [ bless [], 'A' ];
-@$::ra = ('a'..'z');
-pass 'no crash when freeing array that is being cleared';
-
-# [perl #85670] Copying magic to elements
-SKIP: {
-    skip "no Scalar::Util::weaken on miniperl", 1, if is_miniperl;
-    require Scalar::Util;
-    package glelp {
-	Scalar::Util::weaken ($a = \@ISA);
-	@ISA = qw(Foo);
-	Scalar::Util::weaken ($a = \$ISA[0]);
-	::is @ISA, 1, 'backref magic is not copied to elements';
+    {
+        # Test aelemfast for both +ve and -ve indices, both lex and package vars.
+        # Make especially careful that we don't have any edge cases around
+        # fitting an I8 into a U8.
+        my @a = (0..299);
+        is($a[-256], 300-256, 'lex -256');
+        is($a[-255], 300-255, 'lex -255');
+        is($a[-254], 300-254, 'lex -254');
+        is($a[-129], 300-129, 'lex -129');
+        is($a[-128], 300-128, 'lex -128');
+        is($a[-127], 300-127, 'lex -127');
+        is($a[-126], 300-126, 'lex -126');
+        is($a[  -1], 300-  1, 'lex   -1');
+        is($a[   0],       0, 'lex    0');
+        is($a[   1],       1, 'lex    1');
+        is($a[ 126],     126, 'lex  126');
+        is($a[ 127],     127, 'lex  127');
+        is($a[ 128],     128, 'lex  128');
+        is($a[ 129],     129, 'lex  129');
+        is($a[ 254],     254, 'lex  254');
+        is($a[ 255],     255, 'lex  255');
+        is($a[ 256],     256, 'lex  256');
+        @aelem =(0..299);
+        is($aelem[-256], 300-256, 'pkg -256');
+        is($aelem[-255], 300-255, 'pkg -255');
+        is($aelem[-254], 300-254, 'pkg -254');
+        is($aelem[-129], 300-129, 'pkg -129');
+        is($aelem[-128], 300-128, 'pkg -128');
+        is($aelem[-127], 300-127, 'pkg -127');
+        is($aelem[-126], 300-126, 'pkg -126');
+        is($aelem[  -1], 300-  1, 'pkg   -1');
+        is($aelem[   0],       0, 'pkg    0');
+        is($aelem[   1],       1, 'pkg    1');
+        is($aelem[ 126],     126, 'pkg  126');
+        is($aelem[ 127],     127, 'pkg  127');
+        is($aelem[ 128],     128, 'pkg  128');
+        is($aelem[ 129],     129, 'pkg  129');
+        is($aelem[ 254],     254, 'pkg  254');
+        is($aelem[ 255],     255, 'pkg  255');
+        is($aelem[ 256],     256, 'pkg  256');
     }
-}
-package peen {
-    $#ISA = -1;
-    @ISA = qw(Foo);
-    $ISA[0] = qw(Sphare);
 
-    sub Sphare::pling { 'pling' }
+    # Test aelemfast in list assignment
+    @ary = ('a','b');
+    ($ary[0],$ary[1]) = ($ary[1],$ary[0]);
+    is "@ary", 'b a',
+       'aelemfast with the same array on both sides of list assignment';
 
-    ::is eval { peen->pling }, 'pling',
-	'arylen_p magic does not stop isa magic from being copied';
-}
+    for(scalar $#foo) { $_ = 3 }
+    is $#foo, 3, 'assigning to arylen aliased in foreach(scalar $#arylen)';
 
-# Test that &PL_sv_undef is not special in arrays
-sub {
-    ok exists $_[0],
-      'exists returns true for &PL_sv_undef elem [perl #7508]';
-    is \$_[0], \undef, 'undef preserves identity in array [perl #109726]';
-}->(undef);
-# and that padav also knows how to handle the resulting NULLs
-@_ = sub { my @a; $a[1]=1; @a }->();
-is join (" ", map $_//"undef", @_), "undef 1",
-  'returning my @a with nonexistent elements'; 
+    {
+        my @a = qw(a b c);
+        @a = @a;
+        is "@a", 'a b c', 'assigning to itself';
+    }
 
-# [perl #118691]
-@plink=@plunk=();
-$plink[3] = 1;
-sub {
-    $_[0] = 2;
-    is $plink[0], 2, '@_ alias to nonexistent elem within array';
-    $_[1] = 3;
-    is $plink[1], 3, '@_ alias to nonexistent neg index within array';
-    is $_[2], undef, 'reading alias to negative index past beginning';
-    eval { $_[2] = 42 };
-    like $@, qr/Modification of non-creatable array value attempted, (?x:
-               )subscript -5/,
-         'error when setting alias to negative index past beginning';
-    is $_[3], undef, 'reading alias to -1 elem of empty array';
-    eval { $_[3] = 42 };
-    like $@, qr/Modification of non-creatable array value attempted, (?x:
-               )subscript -1/,
-         'error when setting alias to -1 elem of empty array';
-}->($plink[0], $plink[-2], $plink[-5], $plunk[-1]);
+    sub { undef *_; shift }->(); # This would crash; no ok() necessary.
+    sub { undef *_; pop   }->();
 
-$_ = \$#{[]};
-{
-    my @warn;
-    local $SIG{__WARN__} = sub {push @warn, "@_"};
-    $$_ = \1;
-    like ($warn[0], qr/^Attempt to set length of freed array/);
-}
-{
-    no warnings 'void';
-    no warnings 'uninitialized';
-    "$$_";
-}
-pass "no assertion failure after assigning ref to arylen when ary is gone";
-
-
-{
-    # Test aelemfast for both +ve and -ve indices, both lex and package vars.
-    # Make especially careful that we don't have any edge cases around
-    # fitting an I8 into a U8.
-    my @a = (0..299);
-    is($a[-256], 300-256, 'lex -256');
-    is($a[-255], 300-255, 'lex -255');
-    is($a[-254], 300-254, 'lex -254');
-    is($a[-129], 300-129, 'lex -129');
-    is($a[-128], 300-128, 'lex -128');
-    is($a[-127], 300-127, 'lex -127');
-    is($a[-126], 300-126, 'lex -126');
-    is($a[  -1], 300-  1, 'lex   -1');
-    is($a[   0],       0, 'lex    0');
-    is($a[   1],       1, 'lex    1');
-    is($a[ 126],     126, 'lex  126');
-    is($a[ 127],     127, 'lex  127');
-    is($a[ 128],     128, 'lex  128');
-    is($a[ 129],     129, 'lex  129');
-    is($a[ 254],     254, 'lex  254');
-    is($a[ 255],     255, 'lex  255');
-    is($a[ 256],     256, 'lex  256');
-    @aelem =(0..299);
-    is($aelem[-256], 300-256, 'pkg -256');
-    is($aelem[-255], 300-255, 'pkg -255');
-    is($aelem[-254], 300-254, 'pkg -254');
-    is($aelem[-129], 300-129, 'pkg -129');
-    is($aelem[-128], 300-128, 'pkg -128');
-    is($aelem[-127], 300-127, 'pkg -127');
-    is($aelem[-126], 300-126, 'pkg -126');
-    is($aelem[  -1], 300-  1, 'pkg   -1');
-    is($aelem[   0],       0, 'pkg    0');
-    is($aelem[   1],       1, 'pkg    1');
-    is($aelem[ 126],     126, 'pkg  126');
-    is($aelem[ 127],     127, 'pkg  127');
-    is($aelem[ 128],     128, 'pkg  128');
-    is($aelem[ 129],     129, 'pkg  129');
-    is($aelem[ 254],     254, 'pkg  254');
-    is($aelem[ 255],     255, 'pkg  255');
-    is($aelem[ 256],     256, 'pkg  256');
-}
-
-# Test aelemfast in list assignment
-@ary = ('a','b');
-($ary[0],$ary[1]) = ($ary[1],$ary[0]);
-is "@ary", 'b a',
-   'aelemfast with the same array on both sides of list assignment';
-
-for(scalar $#foo) { $_ = 3 }
-is $#foo, 3, 'assigning to arylen aliased in foreach(scalar $#arylen)';
-
-{
-    my @a = qw(a b c);
-    @a = @a;
-    is "@a", 'a b c', 'assigning to itself';
-}
-
-sub { undef *_; shift }->(); # This would crash; no ok() necessary.
-sub { undef *_; pop   }->();
-
-# [perl #129164], [perl #129166], [perl #129167]
-# splice() with null array entries
-# These used to crash.
-$#a = -1; $#a++;
-{
-    no warnings 'uninitialized';
-    () = 0-splice @a; # subtract
+    # [perl #129164], [perl #129166], [perl #129167]
+    # splice() with null array entries
+    # These used to crash.
     $#a = -1; $#a++;
-    () =  -splice @a; # negate
-    $#a = -1; $#a++;
-    () = 0+splice @a; # add
-    # And with array expansion, too
-    $#a = -1; $#a++;
-    () = 0-splice @a, 0, 1, 1, 1;
-    $#a = -1; $#a++;
-    () =  -splice @a, 0, 1, 1, 1;
-    $#a = -1; $#a++;
-    () = 0+splice @a, 0, 1, 1, 1;
-}
+    {
+        no warnings 'uninitialized';
+        () = 0-splice @a; # subtract
+        $#a = -1; $#a++;
+        () =  -splice @a; # negate
+        $#a = -1; $#a++;
+        () = 0+splice @a; # add
+        # And with array expansion, too
+        $#a = -1; $#a++;
+        () = 0-splice @a, 0, 1, 1, 1;
+        $#a = -1; $#a++;
+        () =  -splice @a, 0, 1, 1, 1;
+        $#a = -1; $#a++;
+        () = 0+splice @a, 0, 1, 1, 1;
+    }
+} # END scope of no strict 'vars';
+
 
 # [perl #8910] lazy creation of array elements used to leak out
 {
@@ -758,7 +766,6 @@ $#a = -1; $#a++;
     is "[@a]", "[7 3 1]",
        'holes passed to sub do not lose their position (aelem, mg)';
 }
-use strict;
 
 no warnings 'void';
 "We're included by lib/Tie/Array/std.t so we need to return something true";

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -631,8 +631,10 @@ $#a = -1; $#a++;
     is @a, 0,'unwinding localization of elem past end of array shrinks it';
 
     # Again, but with a package array
+    no warnings 'shadow';
     package tmp; (\our @a)->$#*++; package main;
     my @b = @a;
+    use warnings 'shadow';
     ok !exists $a[0], 'copying an array via = does not vivify elements';
     delete $a[0];
     @a[1..5] = 1..5;
@@ -708,4 +710,5 @@ $#a = -1; $#a++;
        'holes passed to sub do not lose their position (aelem, mg)';
 }
 
+no warnings 'void';
 "We're included by lib/Tie/Array/std.t so we need to return something true";

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -417,11 +417,13 @@ sub test_arylen {
 
 {
     our($x,$y,$z) = (1..3);
+    no warnings 'shadow';
     our($y,$z) = ($x,$y);
     is("$x $y $z", "1 1 2");
 }
 {
     our($x,$y,$z) = (1..3);
+    no warnings 'shadow';
     (our $y, our $z) = ($x,$y);
     is("$x $y $z", "1 1 2");
 }
@@ -429,6 +431,7 @@ sub test_arylen {
     # AASSIGN_COMMON detection with logical operators
     my $true = 1;
     our($x,$y,$z) = (1..3);
+    no warnings 'shadow';
     (our $y, our $z) = $true && ($x,$y);
     is("$x $y $z", "1 1 2");
 }

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -273,7 +273,9 @@ is ($got, '');
 
     is($a[2.1]  , 2);
     is($a[2.9]  , 2);
+    no warnings 'uninitialized';
     is($a[undef], 0);
+    no warnings 'numeric';
     is($a["3rd"], 3);
 }
 

--- a/t/op/array.t
+++ b/t/op/array.t
@@ -694,10 +694,8 @@ is($foo, 'b');
     @a[1..5] = 1..5;
     $#a++;
 
-    undef $count;
-    undef @existing_elements;
+    $count = 0;
     @existing_elements = map { exists $a[$count++] ? $_ : () } @a;
-    use warnings 'shadow';
     is join(",", @existing_elements), "1,2,3,4,5",
        'map {} @a does not vivify elements';
     $#a = -1;


### PR DESCRIPTION
@atoomic `t/op/array.t` required a lot of work.  My objective was to try to narrow the scope of the `use strict;` about 150 lines into the file as much as possible.  So to a considerable extent I had to proceed from the back of the file forward.  Hence, the large number of little commits for this file.