### PR TITLE
Clearify that unicode_strings feature is off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ When using perl from this branch you are going to have the following defaults ou
 * state
 * switch
 * unicode_eval
-* unicode_strings
 
 Note that due to the limitation of features bundles wich can be stored in `HINT_FEATURE_MASK`, some cleanup was made by [401cba074e7](https://github.com/Perl/perl5/commit/401cba074e7458c7f5d4f31dce6334799f4f88ba).
 


### PR DESCRIPTION
Fixes GH #87

Right now regen/feature.pl disable 'unicode_strings'
for the v7.0 bundle.