### PR TITLE
For now enforce 'no indirect by default'

### DIFF
--- a/lib/feature.pm
+++ b/lib/feature.pm
@@ -32,7 +32,7 @@ our %feature_bundle = (
     "5.15"    => [qw(current_sub evalbytes fc indirect say state switch unicode_eval unicode_strings)],
     "5.23"    => [qw(current_sub evalbytes fc indirect postderef_qq say state switch unicode_eval unicode_strings)],
     "5.27"    => [qw(bitwise current_sub evalbytes fc indirect postderef_qq say state switch unicode_eval unicode_strings)],
-    "7.0"     => [qw(bitwise current_sub declared_refs evalbytes fc indirect isa postderef_qq refaliasing say signatures state switch unicode_eval)],
+    "7.0"     => [qw(bitwise current_sub declared_refs evalbytes fc isa postderef_qq refaliasing say signatures state switch unicode_eval)],
     "all"     => [qw(bitwise current_sub declared_refs evalbytes fc indirect isa postderef_qq refaliasing say signatures state switch unicode_eval unicode_strings)],
     "default" => [qw()],
 );

--- a/lib/p7.pm
+++ b/lib/p7.pm
@@ -21,7 +21,7 @@ sub import {
 
     # use warnings; no warnings qw/experimental/;
     # perl -e'use warnings; no warnings qw/experimental/;  my $w; BEGIN {$w = ${^WARNING_BITS} } print unpack("H*", $w) . "\n"'
-    ${^WARNING_BITS} = pack( "H*", '555555555555555555555555150001500101' );
+    ${^WARNING_BITS} = pack( "H*", '55555555555555555555555515000150010154' );
 
     # use strict; use utf8;
     # perl  -MData::Dumper -e'my $h; use strict; use utf8; use feature (qw/bitwise current_sub declared_refs evalbytes fc postderef_qq refaliasing say signatures state switch unicode_eval/); BEGIN {  $h = $^H } printf("\$^H = 0x%08X\n", $h); print Dumper \%^H; '

--- a/perl7.h
+++ b/perl7.h
@@ -27,7 +27,7 @@
 #define P7_TOKE_SETUP "BEGIN { "\
                       "   ${^WARNING_BITS} = pack( 'H*', '555555555555555555555555150001500101' );"\
                       "   $^H |= 0x1C0206E2;"\
-                      "   $^H{feature___SUB__} = 1; $^H{feature_bitwise} = 1; $^H{feature_evalbytes} = 1; $^H{feature_fc} = 1; $^H{feature_myref} = 1; $^H{feature_postderef_qq} = 1; $^H{feature_refaliasing} = 1; $^H{feature_say} = 1; $^H{feature_signatures} = 1; $^H{feature_state} = 1; $^H{feature_switch} = 1; $^H{feature_unieval} = 1;"\
+                      "   $^H{feature___SUB__} = 1; $^H{feature_bitwise} = 1; $^H{feature_evalbytes} = 1; $^H{feature_fc} = 1; $^H{feature_isa} = 1; $^H{feature_myref} = 1; $^H{feature_postderef_qq} = 1; $^H{feature_refaliasing} = 1; $^H{feature_say} = 1; $^H{feature_signatures} = 1; $^H{feature_state} = 1; $^H{feature_switch} = 1; $^H{feature_unieval} = 1;"\
                       "}"
 
 /*

--- a/regen/feature.pl
+++ b/regen/feature.pl
@@ -71,7 +71,7 @@ my %feature_bundle = (
 		    evalbytes current_sub fc postderef_qq bitwise indirect)],
     "5.31"   =>	[qw(say state switch unicode_strings unicode_eval
 		    evalbytes current_sub fc postderef_qq bitwise indirect)],
-    "7.0"   => [ grep { $_ ne 'unicode_strings' } @all_features ],
+    "7.0"   => [ grep { $_ !~ qr{^(?:indirect|unicode_strings)$} } @all_features ],
 );
 
 my @noops = qw( postderef lexical_subs );


### PR DESCRIPTION
We will probably want to promote indirect
as a default, otherwise it will break too
many distro from CPAN.

But having it turn on for now allows us
to track locations in core where we can
convert indirect calls to direct.

This is regenerating files after the rebase
on 5.32.0