### PR TITLE
Remove use p5 20200715

### DIFF
--- a/dist/Devel-SelfStubber/lib/Devel/SelfStubber.pm
+++ b/dist/Devel-SelfStubber/lib/Devel/SelfStubber.pm
@@ -1,4 +1,3 @@
-use p5;
 package Devel::SelfStubber;
 use File::Spec;
 require SelfLoader;

--- a/dist/Filter-Simple/lib/Filter/Simple.pm
+++ b/dist/Filter-Simple/lib/Filter/Simple.pm
@@ -1,6 +1,5 @@
 package Filter::Simple;
 
-use p5;
 use Text::Balanced ':ALL';
 
 our $VERSION = '0.96';

--- a/dist/FindBin/lib/FindBin.pm
+++ b/dist/FindBin/lib/FindBin.pm
@@ -76,8 +76,6 @@ under the same terms as Perl itself.
 
 =cut
 
-use p5;
-
 package FindBin;
 use Carp;
 require 5.000;

--- a/dist/IO/lib/IO/Socket.pm
+++ b/dist/IO/lib/IO/Socket.pm
@@ -7,7 +7,6 @@
 
 package IO::Socket;
 
-use p5;
 use 5.008_001;
 
 use IO::Handle;

--- a/dist/IO/lib/IO/Socket/INET.pm
+++ b/dist/IO/lib/IO/Socket/INET.pm
@@ -5,7 +5,6 @@
 # modify it under the same terms as Perl itself.
 
 package IO::Socket::INET;
-use p5;
 use strict;
 use IO::Socket;
 use Socket;

--- a/dist/IO/lib/IO/Socket/UNIX.pm
+++ b/dist/IO/lib/IO/Socket/UNIX.pm
@@ -5,7 +5,6 @@
 # modify it under the same terms as Perl itself.
 
 package IO::Socket::UNIX;
-use p5;
 use strict;
 use IO::Socket;
 use Carp;

--- a/dist/Net-Ping/lib/Net/Ping.pm
+++ b/dist/Net-Ping/lib/Net/Ping.pm
@@ -1,7 +1,5 @@
 package Net::Ping;
 
-use p5;
-
 require 5.002;
 require Exporter;
 

--- a/dist/Safe/Safe.pm
+++ b/dist/Safe/Safe.pm
@@ -1,6 +1,5 @@
 package Safe;
 
-use p5;
 use 5.003_11;
 use Scalar::Util qw(reftype refaddr);
 

--- a/dist/Test/lib/Test.pm
+++ b/dist/Test/lib/Test.pm
@@ -1,4 +1,3 @@
-use p5;
 require 5.004;
 package Test;
 

--- a/dist/Text-Abbrev/lib/Text/Abbrev.pm
+++ b/dist/Text-Abbrev/lib/Text/Abbrev.pm
@@ -1,6 +1,5 @@
 package Text::Abbrev;
 
-use p5;
 require 5.005;		# Probably works on earlier versions too.
 require Exporter;
 

--- a/dist/XSLoader/XSLoader_pm.PL
+++ b/dist/XSLoader/XSLoader_pm.PL
@@ -11,7 +11,6 @@ print OUT <<'EOT';
 
 package XSLoader;
 
-use p5;
 $VERSION = "0.31"; # remember to update version in POD!
 
 #use strict;

--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -74,7 +74,6 @@ print OUT <<'EOT';
 # Generated from DynaLoader_pm.PL, this file is unique for every OS
 
 package DynaLoader;
-use p5;
 
 #   And Gandalf said: 'Many folk like to know beforehand what is to
 #   be set on the table; but those who have laboured to prepare the

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -1,5 +1,4 @@
 package Hash::Util;
-use p5;
 require 5.007003;
 use strict;
 use Carp;


### PR DESCRIPTION
Placing `use v5;` in a module or test file is potentially seriously misleading.  When am I running a test file to see results and warnings, I am assuming that I am running against Perl 7 semantics.  I could get results that would be either false positives or false negatives.

Just looking at the `dist/` and `ext/` directories, there were 56 files with `use v5;`.  The only file where I could see some justification for doing so was `ext/XS-APItest/t/newCONSTSUB.t`.

Below is the list of such files.  I have separated them into an upper or lower half.  In the lower half are files in directories that I haven't explored much yet because they are very complex, e.g., `dist/Storable`.  In the upper half are files in directories where I've already done a lot of work (albeit presuming I was running Perl 7).

I examined all the files in the upper half.  In every case but two, there was no difference in results between having `use v5;` and not having it.  That is, if the tests ran clean in the first case, they ran clean in the second case.  If the tests still had warnings in the first case, they still had warnings in the second case.

```
$ ack 'use p5' ext/ dist/ 

ext/attributes/attributes.pm
3:use p5; THIS DIRECTORY HAS NO TESTS!

ext/XS-APItest/t/gv_const_sv.t
3:use p5; DIFFERENCE, failures without use p5

ext/XS-APItest/t/eval-filter.t
7:use p5; DIFFERENCE, failures without use p5

ext/DynaLoader/DynaLoader.pm
5:use p5; GENERATED

ext/DynaLoader/DynaLoader_pm.PL
77:use p5; NO DIFFERENCE, changed

dist/FindBin/lib/FindBin.pm
79:use p5; NO DIFFERENCE, changed

dist/IO/lib/IO/Socket.pm
10:use p5; NO DIFFERENCE, changed

dist/IO/lib/IO/Socket/UNIX.pm
8:use p5; NO DIFFERENCE, changed

dist/IO/lib/IO/Socket/INET.pm
8:use p5; NO DIFFERENCE, changed

dist/Net-Ping/Net/Ping.pm
3:use p5; NO DIFFERENCE, changed

dist/Text-Abbrev/lib/Text/Abbrev.pm
3:use p5; NO DIFFERENCE, changed

dist/XSLoader/XSLoader.pm
6:use p5; GENERATED

dist/XSLoader/XSLoader_pm.PL
14:use p5; NO DIFFERENCE, changed

dist/Devel-SelfStubber/lib/Devel/SelfStubber.pm
1:use p5; NO DIFFERENCE, changed

dist/Test/lib/Test.pm
1:use p5; NO DIFFERENCE, changed

dist/Safe/Safe.pm
3:use p5; NO DIFFERENCE, changed

dist/Env/lib/Env.pm
3:use p5; NO DIFFERENCE, changed

dist/Filter-Simple/lib/Filter/Simple.pm
3:use p5;   NO DIFFERENCE, changed

ext/Hash-Util/lib/Hash/Util.pm
2:use p5:   NO DIFFERENCE, changed

##################################################

Directories I haven't touched yet

ext/Devel-Peek/Peek.pm
6:use p5;

ext/XS-APItest/t/newCONSTSUB.t
12: use p5; SPECIAL

dist/Data-Dumper/Dumper.pm
12:use p5;

dist/Storable/t/code.t
9:use p5;

dist/Storable/t/overload.t
9:use p5;

dist/Storable/t/freeze.t
9:use p5;

dist/Storable/t/circular_hook.t
15:use p5;

dist/Storable/t/threads.t
19:use p5;

dist/Storable/t/sig_die.t
9:use p5;

dist/Storable/t/canonical.t
9:use p5;

dist/Storable/t/attach_errors.t
15:use p5;

dist/Storable/t/blessed.t
22:use p5;

dist/Storable/t/interwork56.t
15:use p5;

dist/Storable/t/integer.t
15:use p5;

dist/Storable/t/weak.t
9:use p5;

dist/Storable/t/utf8hash.t
3:use p5;

dist/Storable/t/compat01.t
3:use p5;

dist/Storable/t/utf8.t
9:use p5;

dist/Storable/t/just_plain_nasty.t
8:use p5;

dist/Storable/t/downgrade.t
15:use p5;

dist/Storable/t/dclone.t
9:use p5;

dist/Storable/t/tied.t
9:use p5;

dist/Storable/t/recurse.t
10:use p5;

dist/Storable/t/restrict.t
9:use p5;

dist/Storable/t/attach_singleton.t
12:use p5;

dist/Storable/t/retrieve.t
3:use p5;
13:use p5;

dist/Storable/t/forgive.t
12:use p5;

dist/Storable/t/tied_store.t
3:use p5;

dist/Storable/t/attach.t
5:use p5;

dist/Storable/t/lock.t
9:use p5;

dist/Storable/t/croak.t
8:use p5;

dist/Storable/t/tied_items.t
13:use p5;

dist/Storable/t/compat06.t
9:use p5;

dist/Storable/t/store.t
9:use p5;

dist/Storable/t/tied_hook.t
9:use p5;

dist/Storable/t/malice.t
16:use p5;

dist/threads/lib/threads.pm
3:use p5;

dist/threads-shared/lib/threads/shared.pm
3:use p5;
```
For files in the upper half where there are no changes in results, I have prepared this pull request.

Thank you very much.
Jim Keenan