### PR TITLE
parts/inc/inctools: Quiet uninitialized warnings in Perl 7

### DIFF
--- a/dist/Devel-PPPort/parts/inc/inctools
+++ b/dist/Devel-PPPort/parts/inc/inctools
@@ -86,7 +86,7 @@ sub format_version_line
     return $version;
 }
 
-sub dictionary_order($$)    # Sort caselessly, ignoring punct
+sub dictionary_order    # Sort caselessly, ignoring punct
 {
     my ($lc_a, $lc_b);
     my ($squeezed_a, $squeezed_b);
@@ -101,6 +101,22 @@ sub dictionary_order($$)    # Sort caselessly, ignoring punct
         ($valid_a, $valid_b) = @_;
     }
 
+    if ("$]" >= 7.0000) {
+        return _dictionary_sort_internals_7(
+            $lc_a, $lc_b, $squeezed_a, $squeezed_b, $valid_a, $valid_b
+        );
+    }
+    else {
+        return _dictionary_sort_internals_5(
+            $lc_a, $lc_b, $squeezed_a, $squeezed_b, $valid_a, $valid_b
+        );
+    }
+}
+
+sub _dictionary_sort_internals_7 {
+    my ($lc_a, $lc_b, $squeezed_a, $squeezed_b, $valid_a, $valid_b) = @_;
+
+    no warnings 'uninitialized';
     $lc_a = lc $valid_a;
     $lc_b = lc $valid_b;
 
@@ -113,6 +129,23 @@ sub dictionary_order($$)    # Sort caselessly, ignoring punct
          or       $lc_a cmp $lc_b
          or    $valid_a cmp $valid_b);
 }
+
+sub _dictionary_sort_internals_5 {
+    my ($lc_a, $lc_b, $squeezed_a, $squeezed_b, $valid_a, $valid_b) = @_;
+
+    $lc_a = lc $valid_a;
+    $lc_b = lc $valid_b;
+
+    $squeezed_a = $lc_a;
+    $squeezed_a =~ s/[\W_]//g;   # No punct, including no underscore
+    $squeezed_b = $lc_b;
+    $squeezed_b =~ s/[\W_]//g;
+
+    return( $squeezed_a cmp $squeezed_b
+         or       $lc_a cmp $lc_b
+         or    $valid_a cmp $valid_b);
+}
+
 
 sub sort_api_lines  # Sort lines of the form flags|return|name|args...
                     # by 'name'

--- a/dist/Devel-PPPort/parts/inc/ppphbin
+++ b/dist/Devel-PPPort/parts/inc/ppphbin
@@ -594,7 +594,7 @@ for $filename (@files) {
         diag("Uses $func");
       }
     }
-    $warnings += hint($func);
+    $warnings += (hint($func) || 0);
   }
 
   unless ($opt{quiet}) {
@@ -882,7 +882,7 @@ sub hint
     $hint =~ s/^/   /mg;
     print "   --- hint for $func ---\n", $hint;
   }
-  $rv;
+  $rv || 0;
 }
 
 sub usage

--- a/dist/Devel-PPPort/parts/inc/ppphtest
+++ b/dist/Devel-PPPort/parts/inc/ppphtest
@@ -680,7 +680,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $flags) = /^(\w+)(?:\s+\[(\w+(?:,\s+\w+)*)\])?$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { no warnings 'uninitialized'; exists $p{$name} and $fail++; }
   $p{$name} = defined $flags ? { map { ($_ => 1) } $flags =~ /(\w+)/g } : '';
 }
 ok(@o > 100);
@@ -721,7 +721,7 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $ver) = /^(\w+)\s*\.+\s*([\d._]+)$/ or $fail++;
-  exists $p{$name} and $fail++;
+  { no warnings 'uninitialized'; exists $p{$name} and $fail++; }
   $p{$name} = $ver;
 }
 ok(@o > 100);

--- a/dist/Devel-PPPort/t/ppphtest.t
+++ b/dist/Devel-PPPort/t/ppphtest.t
@@ -721,8 +721,11 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $flags) = /^(\w+)(?:\s+\[(\w+(?:,\s+\w+)*)\])?$/ or $fail++;
-  exists $p{$name} and $fail++;
-  $p{$name} = defined $flags ? { map { ($_ => 1) } $flags =~ /(\w+)/g } : '';
+  {
+    no warnings 'uninitialized';
+    exists $p{$name} and $fail++;
+    $p{$name} = defined $flags ? { map { ($_ => 1) } $flags =~ /(\w+)/g } : '';
+  }
 }
 ok(@o > 100);
 is($fail, 0);
@@ -762,8 +765,11 @@ my %p;
 my $fail = 0;
 for (@o) {
   my($name, $ver) = /^(\w+)\s*\.+\s*([\d._]+)$/ or $fail++;
-  exists $p{$name} and $fail++;
-  $p{$name} = $ver;
+  {
+    no warnings 'uninitialized';
+    exists $p{$name} and $fail++;
+    $p{$name} = $ver;
+  }
 }
 ok(@o > 100);
 is($fail, 0);


### PR DESCRIPTION
The prototype on sub dictionary_sort() was preventing compilation and
wasn't getting us anything.  In particular, that sorting function was/is
being called in many places where one or the other of the two arguments
was uninitialized -- but that's cool.  So let's jettison the prototype.

That enables dist/Devel-PPPort/t/ppphtest.t to compile and run, albeit
shakily.  Running that illustrated the need to further modify
dictionary_sort() to quiet uninitialized value warnings when running in
a Perl 7 environment.  Granted, the solution is not elegant, but it
improves the test output.

After applying this commit, we get this output in testing ppphtest.t:

    Failed 35/238 subtests

    Test Summary Report
    -------------------
    ../dist/Devel-PPPort/t/ppphtest.t (Wstat: 0 Tests: 209 Failed: 6)
      Failed tests:  7, 13, 62, 84, 163-164
      Parse errors: Bad plan.  You planned 238 tests but ran 209.

In p7 branch, we are also only running 209 tests.  I do not yet know why
we're running short of the count.  But the number of outright failures
is now much smaller: a reduction from 187 to 35.