### PR TITLE
No p5 in storable 20200517

### DIFF
--- a/dist/Storable/t/attach.t
+++ b/dist/Storable/t/attach.t
@@ -4,13 +4,14 @@
 
 
 sub BEGIN {
-	unshift @INC, 't';
-	unshift @INC, 't/compat' if $] < 5.006002;
-	require Config; Config->import;
-	if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
-		print "1..0 # Skip: Storable was not built\n";
-		exit 0;
-	}
+    unshift @INC, 't';
+    unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
+    require Config; Config->import;
+    if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
+        print "1..0 # Skip: Storable was not built\n";
+        exit 0;
+    }
 }
 
 use Test::More tests => 3;

--- a/dist/Storable/t/attach.t
+++ b/dist/Storable/t/attach.t
@@ -2,7 +2,7 @@
 #
 # This file tests that Storable correctly uses STORABLE_attach hooks
 
-use p5;
+
 sub BEGIN {
 	unshift @INC, 't';
 	unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/attach_errors.t
+++ b/dist/Storable/t/attach_errors.t
@@ -12,7 +12,7 @@
 # This file tests several known-error cases relating to STORABLE_attach, in
 # which Storable should (correctly) throw errors.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/attach_errors.t
+++ b/dist/Storable/t/attach_errors.t
@@ -144,7 +144,7 @@ use Storable ();
 	# and creating a STORABLE_attach.
 	*My::BadThaw::STORABLE_attach = *My::BadThaw::STORABLE_thaw;
 	*My::BadThaw::STORABLE_attach = *My::BadThaw::STORABLE_thaw; # Suppress a warning
-	delete ${'My::BadThaw::'}{STORABLE_thaw};
+    { no strict 'refs'; delete ${'My::BadThaw::'}{STORABLE_thaw}; }
 
 	# Trigger the error condition
 	my $thawed = undef;
@@ -209,7 +209,7 @@ use Storable ();
 	package My::GoodAttach::Subclass;
 
 	BEGIN {
-		@ISA = 'My::GoodAttach';
+		our @ISA = 'My::GoodAttach';
 	}
 }
 

--- a/dist/Storable/t/attach_errors.t
+++ b/dist/Storable/t/attach_errors.t
@@ -16,6 +16,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/attach_singleton.t
+++ b/dist/Storable/t/attach_singleton.t
@@ -9,7 +9,7 @@
 # Tests freezing/thawing structures containing Singleton objects,
 # which should see both structs pointing to the same object.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/attach_singleton.t
+++ b/dist/Storable/t/attach_singleton.t
@@ -13,6 +13,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/blessed.t
+++ b/dist/Storable/t/blessed.t
@@ -28,6 +28,7 @@ sub BEGIN {
         unshift @INC, 't';
         unshift @INC, 't/compat' if $] < 5.006002;
     }
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/blessed.t
+++ b/dist/Storable/t/blessed.t
@@ -40,7 +40,7 @@ use Test::More;
 
 use Storable qw(freeze thaw store retrieve fd_retrieve);
 
-%::weird_refs = 
+our %weird_refs =
   (REF            => \(my $aref    = []),
    VSTRING        => \(my $vstring = v1.2.3),
    'long VSTRING' => \(my $lvstring = eval "v" . 0 x 300),
@@ -81,14 +81,14 @@ my $longname = "LONG_NAME_" . ('xxxxxxxxxxxxx::' x $m) . "final";
 eval <<EOC;
 package $longname;
 
-\@ISA = ("SHORT_NAME");
+our \@ISA = ("SHORT_NAME");
 EOC
 is($@, '');
 
 eval <<EOC;
 package ${longname}_WITH_HOOK;
 
-\@ISA = ("SHORT_NAME_WITH_HOOK");
+our \@ISA = ("SHORT_NAME_WITH_HOOK");
 EOC
 is($@, '');
 
@@ -185,8 +185,8 @@ foreach $count (1..3) {
 
 package HAS_HOOK;
 
-$loaded_count = 0;
-$thawed_count = 0;
+our $loaded_count = 0;
+our $thawed_count = 0;
 
 sub make {
   bless [];
@@ -222,6 +222,8 @@ is(ref $t, 'HAS_HOOK');
 {
     package STRESS_THE_STACK;
 
+    our $freeze_count = 0;
+    our $thaw_count = 0;
     my $stress;
     sub make {
 	bless [];
@@ -308,9 +310,14 @@ is(ref $t, 'STRESS_THE_STACK');
         if ($weird =~ 'VSTRING') {
             # It is not just Storable that did not support vstrings. :-)
             # See https://rt.cpan.org/Ticket/Display.html?id=78678
-            my $newver = "version"->can("new")
+            my $newver;
+            {
+                # Integer overflow in version (twice)
+                no warnings 'overflow';
+                $newver = "version"->can("new")
                            ? sub { "version"->new(shift) }
                            : sub { "" };
+            }
             if (!ok
                   $$thawn eq $$obj && &$newver($$thawn) eq &$newver($$obj),
                  "get the right value back"

--- a/dist/Storable/t/blessed.t
+++ b/dist/Storable/t/blessed.t
@@ -19,7 +19,7 @@ BEGIN {
     );
 }
 
-use p5;
+
 sub BEGIN {
     if ($ENV{PERL_CORE}) {
         chdir 'dist/Storable' if -d 'dist/Storable';

--- a/dist/Storable/t/canonical.t
+++ b/dist/Storable/t/canonical.t
@@ -28,29 +28,31 @@ use Test::More tests => 8;
 # (you may want to reduce the size of the hashes too)
 # $debugging = 1;
 
-$hashsize = 100;
-$maxhash2size = 100;
-$maxarraysize = 100;
+my $hashsize = 100;
+my $maxhash2size = 100;
+my $maxarraysize = 100;
 
 # Use Digest::MD5 if its available to make random string keys
 
 eval { require Digest::MD5; };
-$gotmd5 = !$@;
-diag "Will use Digest::MD5" if $gotmd5;
+my $gotmd5 = !$@;
+note "Will use Digest::MD5" if $gotmd5;
 
 # Use Data::Dumper if debugging and it is available to create an ASCII dump
 
+my $gotdd;
 if ($debugging) {
     eval { require "Data/Dumper.pm" };
     $gotdd  = !$@;
 }
 
-@fixed_strings = ("January", "February", "March", "April", "May", "June",
+my @fixed_strings = ("January", "February", "March", "April", "May", "June",
 		  "July", "August", "September", "October", "November", "December" );
 
 # Build some arbitrarily complex data structure starting with a top level hash
 # (deeper levels contain scalars, references to hashes or references to arrays);
 
+my %a1;
 for (my $i = 0; $i < $hashsize; $i++) {
 	my($k) = int(rand(1_000_000));
 	$k = Digest::MD5::md5_hex($k) if $gotmd5 and int(rand(2));
@@ -86,22 +88,23 @@ print STDERR Data::Dumper::Dumper(\%a1) if ($verbose and $gotdd);
 
 # Copy the hash, element by element in order of the keys
 
-foreach $k (sort keys %a1) {
+my %a2;
+foreach my $k (sort keys %a1) {
     $a2{$k} = { key => "$k", "value" => $a1{$k}->{value} };
 }
 
 # Deep clone the hash
 
-$a3 = dclone(\%a1);
+my $a3 = dclone(\%a1);
 
 # In canonical mode the frozen representation of each of the hashes
 # should be identical
 
 $Storable::canonical = 1;
 
-$x1 = freeze(\%a1);
-$x2 = freeze(\%a2);
-$x3 = freeze($a3);
+my $x1 = freeze(\%a1);
+my $x2 = freeze(\%a2);
+my $x3 = freeze($a3);
 
 cmp_ok(length $x1, '>', $hashsize);	# sanity check
 is(length $x1, length $x2);		# idem

--- a/dist/Storable/t/canonical.t
+++ b/dist/Storable/t/canonical.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #  
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/canonical.t
+++ b/dist/Storable/t/canonical.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/circular_hook.t
+++ b/dist/Storable/t/circular_hook.t
@@ -12,7 +12,7 @@
 # This file tests several known-error cases relating to STORABLE_attach, in
 # which Storable should (correctly) throw errors.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/circular_hook.t
+++ b/dist/Storable/t/circular_hook.t
@@ -56,7 +56,7 @@ is_deeply( \@Foo::order, [ 'Bar', 'Foo' ], 'thaw order is correct (depth first)'
 
 package Foo;
 
-@order = ();
+our @order = ();
 
 sub STORABLE_freeze {
 	my ($self, $clone) = @_;
@@ -83,7 +83,7 @@ sub STORABLE_thaw {
 package Bar;
 
 BEGIN {
-@ISA = 'Foo';
+our @ISA = 'Foo';
 }
 
 1;

--- a/dist/Storable/t/circular_hook.t
+++ b/dist/Storable/t/circular_hook.t
@@ -16,6 +16,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/code.t
+++ b/dist/Storable/t/code.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/code.t
+++ b/dist/Storable/t/code.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/compat01.t
+++ b/dist/Storable/t/compat01.t
@@ -5,6 +5,7 @@
 BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/compat01.t
+++ b/dist/Storable/t/compat01.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use p5;
+
 
 BEGIN {
     unshift @INC, 't';

--- a/dist/Storable/t/compat06.t
+++ b/dist/Storable/t/compat06.t
@@ -11,6 +11,7 @@
 BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/compat06.t
+++ b/dist/Storable/t/compat06.t
@@ -54,9 +54,11 @@ sub make {
 
 package ROOT;
 
+our %hash;
 sub make {
 	my $self = bless {}, shift;
-	my $h = tie %hash, TIED_HASH;
+	my $h;
+	{ no strict 'subs'; $h = tie %hash, TIED_HASH; }
 	$self->{h} = $h;
 	$self->{ref} = \%hash;
 	my @pool;
@@ -79,6 +81,7 @@ sub obj { $_[0]->{obj} }
 
 package main;
 
+our $hash_fetch;
 my $is_EBCDIC = (ord('A') == 193) ? 1 : 0;
  
 my $r = ROOT->make;

--- a/dist/Storable/t/compat06.t
+++ b/dist/Storable/t/compat06.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 
 BEGIN {
     unshift @INC, 't';

--- a/dist/Storable/t/croak.t
+++ b/dist/Storable/t/croak.t
@@ -5,7 +5,7 @@
 # with 5.005_03. This test shows it up, whereas malice.t does not.
 # In particular, don't use Test; as this covers up the problem.
 
-use p5;
+
 sub BEGIN {
     if ($ENV{PERL_CORE}) {
 	require Config; Config->import;

--- a/dist/Storable/t/croak.t
+++ b/dist/Storable/t/croak.t
@@ -8,12 +8,13 @@
 
 sub BEGIN {
     if ($ENV{PERL_CORE}) {
-	require Config; Config->import;
-	%Config=%Config if 0; # cease -w
-	if ($Config{'extensions'} !~ /\bStorable\b/) {
-	    print "1..0 # Skip: Storable was not built\n";
-	    exit 0;
-	}
+        no strict 'vars';
+        require Config; Config->import;
+        %Config=%Config if 0; # cease -w
+        if ($Config{'extensions'} !~ /\bStorable\b/) {
+            print "1..0 # Skip: Storable was not built\n";
+            exit 0;
+        }
     }
 }
 

--- a/dist/Storable/t/dclone.t
+++ b/dist/Storable/t/dclone.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/dclone.t
+++ b/dist/Storable/t/dclone.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/dclone.t
+++ b/dist/Storable/t/dclone.t
@@ -24,36 +24,38 @@ use Storable qw(dclone);
 
 use Test::More tests => 14;
 
-$a = 'toto';
-$b = \$a;
-$c = bless {}, CLASS;
+my $a = 'toto';
+my $b = \$a;
+my $c;
+{ no strict 'subs'; $c = bless {}, CLASS; }
 $c->{attribute} = 'attrval';
-%a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
-@a = ('first', undef, 3, -4, -3.14159, 456, 4.5,
+my %a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
+my @a = ('first', undef, 3, -4, -3.14159, 456, 4.5,
 	$b, \$a, $a, $c, \$c, \%a);
 
 my $aref = dclone(\@a);
 isnt($aref, undef);
 
-$dumped = &dump(\@a);
+my $dumped = &dump(\@a);
 isnt($dumped, undef);
 
-$got = &dump($aref);
+my $got = &dump($aref);
 isnt($got, undef);
 
 is($got, $dumped);
 
-package FOO; @ISA = qw(Storable);
+package FOO; our @ISA = qw(Storable);
 
 sub make {
 	my $self = bless {};
+	no warnings 'once';
 	$self->{key} = \%main::a;
 	return $self;
 };
 
 package main;
 
-$foo = FOO->make;
+my $foo = FOO->make;
 my $r = $foo->dclone;
 isnt($r, undef);
 

--- a/dist/Storable/t/downgrade.t
+++ b/dist/Storable/t/downgrade.t
@@ -12,7 +12,7 @@
 # This test checks downgrade behaviour on pre-5.8 perls when new 5.8 features
 # are encountered.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/downgrade.t
+++ b/dist/Storable/t/downgrade.t
@@ -16,6 +16,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/downgrade.t
+++ b/dist/Storable/t/downgrade.t
@@ -118,7 +118,7 @@ sub test_locked_hash {
   my $hash = shift;
   my @keys = keys %$hash;
   my ($key, $value) = each %$hash;
-  eval {$hash->{$key} = reverse $value};
+  eval {no warnings 'uninitialized'; $hash->{$key} = reverse $value};
   like( $@, "/^Modification of a read-only value attempted/",
         'trying to change a locked key' );
   is ($hash->{$key}, $value, "hash should not change?");
@@ -132,14 +132,17 @@ sub test_restricted_hash {
   my $hash = shift;
   my @keys = keys %$hash;
   my ($key, $value) = each %$hash;
-  eval {$hash->{$key} = reverse $value};
+  eval {no warnings 'uninitialized'; $hash->{$key} = reverse $value};
   is( $@, '',
         'trying to change a restricted key' );
-  is ($hash->{$key}, reverse ($value), "hash should change");
-  eval {$hash->{use} = 'perl'};
-  like( $@, "/^Attempt to access disallowed key 'use' in a restricted hash/",
+  {
+    no warnings 'uninitialized';
+    is ($hash->{$key}, reverse ($value), "hash should change");
+    eval {$hash->{use} = 'perl'};
+    like( $@, "/^Attempt to access disallowed key 'use' in a restricted hash/",
         'trying to add another key' );
-  ok (eq_array([keys %$hash], \@keys), "Still the same keys?");
+    ok (eq_array([keys %$hash], \@keys), "Still the same keys?");
+  }
 }
 
 sub test_placeholder {

--- a/dist/Storable/t/forgive.t
+++ b/dist/Storable/t/forgive.t
@@ -9,7 +9,7 @@
 # (C) Copyright 1997, Universitat Dortmund, all rights reserved.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/forgive.t
+++ b/dist/Storable/t/forgive.t
@@ -13,6 +13,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/freeze.t
+++ b/dist/Storable/t/freeze.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/freeze.t
+++ b/dist/Storable/t/freeze.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/freeze.t
+++ b/dist/Storable/t/freeze.t
@@ -25,50 +25,52 @@ $Storable::flags = Storable::FLAGS_COMPAT;
 
 use Test::More tests => 21;
 
-$a = 'toto';
-$b = \$a;
-$c = bless {}, CLASS;
+my $a = 'toto';
+my $b = \$a;
+my $c;
+{ no strict 'subs'; $c = bless {}, CLASS; }
 $c->{attribute} = $b;
-$d = {};
-$e = [];
+my $d = {};
+my $e = [];
 $d->{'a'} = $e;
 $e->[0] = $d;
-%a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
-@a = ('first', undef, 3, -4, -3.14159, 456, 4.5, $d, \$d, \$e, $e,
+my %a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
+my @a = ('first', undef, 3, -4, -3.14159, 456, 4.5, $d, \$d, \$e, $e,
 	$b, \$a, $a, $c, \$c, \%a);
 
 my $f1 = freeze(\@a);
 isnt($f1, undef);
 
-$dumped = &dump(\@a);
+my $dumped = &dump(\@a);
 isnt($dumped, undef);
 
-$root = thaw($f1);
+my $root = thaw($f1);
 isnt($root, undef);
 
-$got = &dump($root);
+my $got = &dump($root);
 isnt($got, undef);
 
 is($got, $dumped);
 
-package FOO; @ISA = qw(Storable);
+package FOO; our @ISA = qw(Storable);
 
 sub make {
 	my $self = bless {};
+    no warnings 'once';
 	$self->{key} = \%main::a;
 	return $self;
 };
 
 package main;
 
-$foo = FOO->make;
+my $foo = FOO->make;
 my $f2 = $foo->freeze;
 isnt($f2, undef);
 
 my $f3 = $foo->nfreeze;
 isnt($f3, undef);
 
-$root3 = thaw($f3);
+my $root3 = thaw($f3);
 isnt($root3, undef);
 
 is(&dump($foo), &dump($root3));
@@ -78,13 +80,13 @@ is(&dump($foo), &dump($root));
 
 is(&dump($root3), &dump($root));
 
-$other = freeze($root);
+my $other = freeze($root);
 is(length$other, length $f2);
 
-$root2 = thaw($other);
+my $root2 = thaw($other);
 is(&dump($root2), &dump($root));
 
-$VAR1 = [
+my $VAR1 = [
 	'method',
 	1,
 	'prepare',
@@ -92,8 +94,8 @@ $VAR1 = [
                   where table_owner != \'$ingres\' and table_owner != \'DBA\''
 ];
 
-$x = nfreeze($VAR1);
-$VAR2 = thaw($x);
+my $x = nfreeze($VAR1);
+my $VAR2 = thaw($x);
 is($VAR2->[3], $VAR1->[3]);
 
 # Test the workaround for LVALUE bug in perl 5.004_04 -- from Gisle Aas

--- a/dist/Storable/t/integer.t
+++ b/dist/Storable/t/integer.t
@@ -12,7 +12,7 @@
 # This test checks downgrade behaviour on pre-5.8 perls when new 5.8 features
 # are encountered.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/integer.t
+++ b/dist/Storable/t/integer.t
@@ -16,6 +16,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/interwork56.t
+++ b/dist/Storable/t/interwork56.t
@@ -12,7 +12,7 @@
 # This test checks whether the kludge to interwork with 5.6 Storables compiled
 # on Unix systems with IV as long long works.
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/interwork56.t
+++ b/dist/Storable/t/interwork56.t
@@ -16,6 +16,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/just_plain_nasty.t
+++ b/dist/Storable/t/just_plain_nasty.t
@@ -9,6 +9,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/just_plain_nasty.t
+++ b/dist/Storable/t/just_plain_nasty.t
@@ -5,7 +5,7 @@
 
 #  Everyone's invited! :-D
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/lock.t
+++ b/dist/Storable/t/lock.t
@@ -29,7 +29,7 @@ unless (&Storable::CAN_FLOCK) {
 
 plan(tests => 5);
 
-@a = ('first', undef, 3, -4, -3.14159, 456, 4.5);
+my @a = ('first', undef, 3, -4, -3.14159, 456, 4.5);
 
 #
 # We're just ensuring things work, we're not validating locking.
@@ -39,7 +39,7 @@ isnt(lock_store(\@a, "store$$"), undef);
 my $dumped = &dump(\@a);
 isnt($dumped, undef);
 
-$root = lock_retrieve("store$$");
+my $root = lock_retrieve("store$$");
 is(ref $root, 'ARRAY');
 is(scalar @a, scalar @$root);
 is(&dump($root), $dumped);

--- a/dist/Storable/t/lock.t
+++ b/dist/Storable/t/lock.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/lock.t
+++ b/dist/Storable/t/lock.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/malice.t
+++ b/dist/Storable/t/malice.t
@@ -18,6 +18,7 @@ sub BEGIN {
     # This lets us distribute Test::More in t/
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/malice.t
+++ b/dist/Storable/t/malice.t
@@ -13,7 +13,7 @@
 # error traps in Storable as possible
 # It also acts as a test for read_header
 
-use p5;
+
 sub BEGIN {
     # This lets us distribute Test::More in t/
     unshift @INC, 't';

--- a/dist/Storable/t/overload.t
+++ b/dist/Storable/t/overload.t
@@ -31,18 +31,19 @@ use overload
 
 package main;
 
-$a = bless [77], OVERLOADED;
+my $a;
+{ no strict 'subs'; $a = bless [77], OVERLOADED; }
 
-$b = thaw freeze $a;
+my $b = thaw freeze $a;
 is(ref $b, 'OVERLOADED');
 is("$b", "77");
 
-$c = thaw freeze \$a;
+my $c = thaw freeze \$a;
 is(ref $c, 'REF');
 is(ref $$c, 'OVERLOADED');
 is("$$c", "77");
 
-$d = thaw freeze [$a, $a];
+my $d = thaw freeze [$a, $a];
 is("$d->[0]", "77");
 $d->[0][0]++;
 is("$d->[1]", "78");

--- a/dist/Storable/t/overload.t
+++ b/dist/Storable/t/overload.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #  
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/overload.t
+++ b/dist/Storable/t/overload.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/recurse.t
+++ b/dist/Storable/t/recurse.t
@@ -7,7 +7,7 @@
 #  
 use Config;
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/recurse.t
+++ b/dist/Storable/t/recurse.t
@@ -27,7 +27,7 @@ package OBJ_REAL;
 
 use Storable qw(freeze thaw);
 
-@x = ('a', 1);
+our @x = ('a', 1);
 
 sub make { bless [], shift }
 
@@ -53,7 +53,7 @@ sub STORABLE_thaw {
 
 package OBJ_SYNC;
 
-@x = ('a', 1);
+our @x = ('a', 1);
 
 sub make { bless {}, shift }
 
@@ -107,9 +107,9 @@ package OBJ_REAL2;
 
 use Storable qw(freeze thaw);
 
-$MAX = 20;
-$recursed = 0;
-$hook_called = 0;
+our $MAX = 20;
+my $recursed = 0;
+my $hook_called = 0;
 
 sub make { bless [], shift }
 
@@ -217,7 +217,7 @@ sub STORABLE_thaw {
 
 package main;
 
-my $bar = new Bar;
+my $bar = Bar->new ;
 my $bar2 = thaw freeze $bar;
 
 is(ref($bar2), 'Bar');
@@ -322,10 +322,11 @@ is($refcount_ok, 1, "check refcount");
 
 local $Storable::recursion_limit = 30;
 local $Storable::recursion_limit_hash = 20;
-sub MAX_DEPTH () { Storable::stack_depth() }
-sub MAX_DEPTH_HASH () { Storable::stack_depth_hash() }
+sub MAX_DEPTH { Storable::stack_depth() }
+sub MAX_DEPTH_HASH { Storable::stack_depth_hash() }
 {
     my $t;
+    no strict 'subs';
     print "# max depth ", MAX_DEPTH, "\n";
     $t = [$t] for 1 .. MAX_DEPTH;
     dclone $t;

--- a/dist/Storable/t/restrict.t
+++ b/dist/Storable/t/restrict.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/retrieve.t
+++ b/dist/Storable/t/retrieve.t
@@ -15,6 +15,7 @@ sub BEGIN {
     unshift @INC, 'dist/Storable/t' if $ENV{PERL_CORE} and -d 'dist/Storable/t';
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/retrieve.t
+++ b/dist/Storable/t/retrieve.t
@@ -1,6 +1,6 @@
 #!./perl
 
-use p5;
+
 
 #
 #  Copyright (c) 1995-2000, Raphael Manfredi
@@ -10,7 +10,7 @@ use p5;
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 'dist/Storable/t' if $ENV{PERL_CORE} and -d 'dist/Storable/t';
     unshift @INC, 't';

--- a/dist/Storable/t/retrieve.t
+++ b/dist/Storable/t/retrieve.t
@@ -28,12 +28,13 @@ sub BEGIN {
 use Storable qw(store retrieve nstore);
 use Test::More tests => 20;
 
-$a = 'toto';
-$b = \$a;
-$c = bless {}, CLASS;
+my $a = 'toto';
+my $b = \$a;
+my $c;
+{ no strict 'subs'; $c = bless {}, CLASS; }
 $c->{attribute} = 'attrval';
-%a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
-@a = ('first', '', undef, 3, -4, -3.14159, 456, 4.5,
+my %a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$c);
+my @a = ('first', '', undef, 3, -4, -3.14159, 456, 4.5,
 	$b, \$a, $a, $c, \$c, \%a);
 
 isnt(store(\@a, "store$$"), undef);
@@ -42,17 +43,17 @@ isnt(nstore(\@a, 'nstore'), undef);
 is(Storable::last_op_in_netorder(), 1);
 is(Storable::last_op_in_netorder(), 1);
 
-$root = retrieve("store$$");
+my $root = retrieve("store$$");
 isnt($root, undef);
 is(Storable::last_op_in_netorder(), '');
 
-$nroot = retrieve('nstore');
+my $nroot = retrieve('nstore');
 isnt($root, undef);
 is(Storable::last_op_in_netorder(), 1);
 
-$d1 = &dump($root);
+my $d1 = &dump($root);
 isnt($d1, undef);
-$d2 = &dump($nroot);
+my $d2 = &dump($nroot);
 isnt($d2, undef);
 
 is($d1, $d2);

--- a/dist/Storable/t/sig_die.t
+++ b/dist/Storable/t/sig_die.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 
 sub BEGIN {
     unshift @INC, 't';

--- a/dist/Storable/t/sig_die.t
+++ b/dist/Storable/t/sig_die.t
@@ -11,6 +11,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/store.t
+++ b/dist/Storable/t/store.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/store.t
+++ b/dist/Storable/t/store.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/threads.t
+++ b/dist/Storable/t/threads.t
@@ -16,7 +16,7 @@
 # Storable::init_perinterp() to create a new context for each new
 # thread when it starts
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/threads.t
+++ b/dist/Storable/t/threads.t
@@ -20,6 +20,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/tied.t
+++ b/dist/Storable/t/tied.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/tied.t
+++ b/dist/Storable/t/tied.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/tied_hook.t
+++ b/dist/Storable/t/tied_hook.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/tied_hook.t
+++ b/dist/Storable/t/tied_hook.t
@@ -10,6 +10,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/tied_hook.t
+++ b/dist/Storable/t/tied_hook.t
@@ -25,7 +25,10 @@ $Storable::flags = Storable::FLAGS_COMPAT;
 
 use Test::More tests => 28;
 
-($scalar_fetch, $array_fetch, $hash_fetch) = (0, 0, 0);
+our ($scalar_fetch, $array_fetch, $hash_fetch) = (0, 0, 0);
+our ($scalar_hook1, $scalar_hook2);
+our ($array_hook1, $array_hook2);
+our ($hash_hook1, $hash_hook2);
 
 package TIED_HASH;
 
@@ -146,12 +149,16 @@ sub STORABLE_thaw {
 
 package main;
 
-$a = 'toto';
-$b = \$a;
+my $a = 'toto';
+my $b = \$a;
 
-$c = tie %hash, TIED_HASH;
-$d = tie @array, TIED_ARRAY;
-tie $scalar, TIED_SCALAR;
+my ($c, $d, %hash, @array, $scalar);
+{
+    no strict 'subs';
+    $c = tie %hash, TIED_HASH;
+    $d = tie @array, TIED_ARRAY;
+    tie $scalar, TIED_SCALAR;
+}
 
 $scalar = 'foo';
 $hash{'attribute'} = 'plain value';
@@ -160,41 +167,42 @@ $array[1] = $c;
 $array[2] = \@array;
 $array[3] = "plaine scalaire";
 
-@tied = (\$scalar, \@array, \%hash);
-%a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$a, 'scalarref', \$scalar);
-@a = ('first', 3, -4, -3.14159, 456, 4.5, $d, \$d,
+my @tied = (\$scalar, \@array, \%hash);
+my %a = ('key', 'value', 1, 0, $a, $b, 'cvar', \$a, 'scalarref', \$scalar);
+my @a = ('first', 3, -4, -3.14159, 456, 4.5, $d, \$d,
 	$b, \$a, $a, $c, \$c, \%a, \@array, \%hash, \@tied);
 
 my $f = freeze(\@a);
 isnt($f, undef);
-$dumped = &dump(\@a);
+my $dumped = &dump(\@a);
 isnt($dumped, undef);
 
-$root = thaw($f);
+my $root = thaw($f);
 isnt($root, undef);
 
-$got = &dump($root);
+my $got = &dump($root);
 isnt($got, undef);
 
 isnt($got, $dumped);		# our hooks did not handle refs in array
 
-$g = freeze($root);
+my $g = freeze($root);
 is(length $f, length $g);
 
 # Ensure the tied items in the retrieved image work
-@old = ($scalar_fetch, $array_fetch, $hash_fetch);
+my @old = ($scalar_fetch, $array_fetch, $hash_fetch);
+my ($tscalar, $tarray, $thash);
 @tied = ($tscalar, $tarray, $thash) = @{$root->[$#{$root}]};
-@type = qw(SCALAR  ARRAY  HASH);
+my @type = qw(SCALAR  ARRAY  HASH);
 
 is(ref tied $$tscalar, 'TIED_SCALAR');
 is(ref tied @$tarray, 'TIED_ARRAY');
 is(ref tied %$thash, 'TIED_HASH');
 
-@new = ($$tscalar, $tarray->[0], $thash->{'attribute'});
+my @new = ($$tscalar, $tarray->[0], $thash->{'attribute'});
 @new = ($scalar_fetch, $array_fetch, $hash_fetch);
 
 # Tests 10..15
-for ($i = 0; $i < @new; $i++) {
+for (my $i = 0; $i < @new; $i++) {
     is($new[$i], $old[$i] + 1);		# Tests 10,12,14
     is(ref $tied[$i], $type[$i]);	# Tests 11,13,15
 }

--- a/dist/Storable/t/tied_items.t
+++ b/dist/Storable/t/tied_items.t
@@ -10,7 +10,7 @@
 # Tests ref to items in tied hash/array structures.
 #
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/tied_items.t
+++ b/dist/Storable/t/tied_items.t
@@ -14,6 +14,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/tied_items.t
+++ b/dist/Storable/t/tied_items.t
@@ -29,26 +29,28 @@ use Test::More tests => 8;
 
 $Storable::flags = Storable::FLAGS_COMPAT;
 
-$h_fetches = 0;
+my $h_fetches = 0;
 
 sub H::TIEHASH { bless \(my $x), "H" }
 sub H::FETCH { $h_fetches++; $_[1] - 70 }
 
+my %h;
 tie %h, "H";
 
-$ref = \$h{77};
-$ref2 = dclone $ref;
+my $ref = \$h{77};
+my $ref2 = dclone $ref;
 
 is($h_fetches, 0);
 is($$ref2, $$ref);
 is($$ref2, 7);
 is($h_fetches, 2);
 
-$a_fetches = 0;
+my $a_fetches = 0;
 
 sub A::TIEARRAY { bless \(my $x), "A" }
 sub A::FETCH { $a_fetches++; $_[1] - 70 }
 
+my @a;
 tie @a, "A";
 
 $ref = \$a[78];

--- a/dist/Storable/t/tied_store.t
+++ b/dist/Storable/t/tied_store.t
@@ -4,6 +4,7 @@
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/tied_store.t
+++ b/dist/Storable/t/tied_store.t
@@ -1,6 +1,6 @@
 #!./perl
 
-use p5;
+
 sub BEGIN {
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;

--- a/dist/Storable/t/utf8.t
+++ b/dist/Storable/t/utf8.t
@@ -15,6 +15,7 @@ sub BEGIN {
     }
     unshift @INC, 't';
     unshift @INC, 't/compat' if $] < 5.006002;
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
         print "1..0 # Skip: Storable was not built\n";

--- a/dist/Storable/t/utf8.t
+++ b/dist/Storable/t/utf8.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 
 sub BEGIN {
     if ($] < 5.006) {

--- a/dist/Storable/t/utf8hash.t
+++ b/dist/Storable/t/utf8hash.t
@@ -1,6 +1,6 @@
 #!./perl
 
-use p5;
+
 
 sub BEGIN {
     if ($] < 5.007) {

--- a/dist/Storable/t/utf8hash.t
+++ b/dist/Storable/t/utf8hash.t
@@ -8,6 +8,7 @@ sub BEGIN {
 	exit 0;
     }
     unshift @INC, 't';
+    no strict 'vars';
     require Config; Config->import;
     if ($ENV{PERL_CORE}){
 	if($Config{'extensions'} !~ /\bStorable\b/) {

--- a/dist/Storable/t/weak.t
+++ b/dist/Storable/t/weak.t
@@ -6,7 +6,7 @@
 #  in the README file that comes with the distribution.
 #
 
-use p5;
+
 
 sub BEGIN {
   # This lets us distribute Test::More in t/

--- a/dist/Storable/t/weak.t
+++ b/dist/Storable/t/weak.t
@@ -12,6 +12,7 @@ sub BEGIN {
   # This lets us distribute Test::More in t/
   unshift @INC, 't';
   unshift @INC, 't/compat' if $] < 5.006002;
+  no strict 'vars';
   require Config; Config->import;
   if ($ENV{PERL_CORE} and $Config{'extensions'} !~ /\bStorable\b/) {
     print "1..0 # Skip: Storable was not built\n";


### PR DESCRIPTION
In `p7`, all `dist/Storable/t/*.t` files currently `use p5;`.  This hides the ways these tests are failing.  In this p.r., I first removed this from all test files.  They all failed at that point.  However, when I then added a `no strict 'vars';` in the `BEGIN` block before `require Config; Config->import;` -- as we've done in dozens of other files, all the tests became somewhat runnable and about half of them immediately began to PASS and run with no warnings.

For the others I was able to get substantial improvements by just honoring strictures.  The test files were originally written with next to no regard for strict 'vars' and 'subs'.  Global variables all over the place.  Many files have multiple packages, veering back and forth between `main` and other packages.  So in places it was difficult to determine whether a given variable should be declared with `my` or `our`.  Consequently some of my edits may have caused the tests to deviate from the original author's intent.

Fortunately, however, many of the files in this directory were written with copy-and-paste.  So that meant that I saw the same global variables in file after file.  After a dozen of these, I could open up a file and start fixing the globals without even looking at a prior test output.

8 files in this directory still have non-trivial failures.
```
../dist/Storable/t/code.t            (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 63 tests but ran 0.
../dist/Storable/t/downgrade.t       (Wstat: 7936 Tests: 169 Failed: 31)
  Failed tests:  13-14, 18-19, 29, 34-35, 45, 50-51, 61
                66-67, 77-78, 82-83, 93-95, 98-99, 109-110
                114-115, 125-127, 130-131
  Non-zero exit status: 31
../dist/Storable/t/malice.t          (Wstat: 5120 Tests: 420 Failed: 20)
  Failed tests:  8, 109-110, 130, 132, 135, 226-227, 247
                249, 257, 327-328, 338, 340, 343, 403-404
                414, 416
  Non-zero exit status: 20
../dist/Storable/t/recurse.t         (Wstat: 1536 Tests: 39 Failed: 6)
  Failed tests:  14-15, 17, 20-21, 37
  Non-zero exit status: 6
../dist/Storable/t/regexp.t          (Wstat: 65280 Tests: 4 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 64 tests but ran 4.
../dist/Storable/t/restrict.t        (Wstat: 45056 Tests: 304 Failed: 176)
  Failed tests:  1, 5, 9-25, 27, 31, 35-51, 53, 57, 61-77
                79, 83, 87-103, 105, 107, 109, 111, 113
                115, 117, 119, 121, 123, 125, 127, 129
                131, 133, 135, 137, 139, 141, 143, 145
                147, 149, 151, 153, 155, 157, 159, 161
                163, 165, 167, 169, 171, 173, 175, 177
                179, 181, 183, 185, 187, 189, 191, 193
                195, 197, 199, 201, 203, 205, 207, 209
                211, 213, 215, 217, 219, 221, 223, 225
                227, 229, 231, 233, 235, 237, 239, 241
                243, 245, 247, 249, 251, 253, 255, 257
                259, 261, 263, 265, 267, 269, 271, 273
                275, 277, 279, 281, 283, 285, 287, 289
                291, 293, 295, 297, 299, 301, 303
  Non-zero exit status: 176
../dist/Storable/t/tied.t            (Wstat: 768 Tests: 25 Failed: 3)
  Failed tests:  17, 19, 22
  Non-zero exit status: 3
../dist/Storable/t/weak.t            (Wstat: 6400 Tests: 128 Failed: 0)
  Non-zero exit status: 25
Files=43, Tests=2587,  3 wallclock secs ( 0.22 usr  0.05 sys +  2.53 cusr  0.27 csys =  3.07 CPU)
Result: FAIL
```
Nonetheless, I feel that, in order to reap the benefit of seeing that the other 35 files now PASS with Perl 7 semantics, I believe we should merge this branch, then open up individual tickets for the files still failing.

Thank you very much.
Jim Keenan