### PR TITLE
Restore 'use 5.x' behavior as it behaves in Perl 5

### DIFF
--- a/cpan/ExtUtils-Constant/t/Constant.t
+++ b/cpan/ExtUtils-Constant/t/Constant.t
@@ -409,7 +409,11 @@ EOT
   push @files, $pm;
   open FH, ">$pm" or die "open >$pm: $!\n";
   print FH "package $package;\n";
-  print FH "use $];\n";
+  if ( "$]" < 7 ) {
+    print FH "use $];\n";
+  } else {
+    print FH "use v".int($]).";\n";
+  }
 
   print FH <<'EOT';
 

--- a/pp_ctl.c
+++ b/pp_ctl.c
@@ -3753,23 +3753,61 @@ static OP *
 S_require_version(pTHX_ SV *sv)
 {
     dVAR; dSP;
+    const char *str_version;
+    const char *ptr;
+    SV *sv_last_five_version;
+    SV *req;
+    SV *pv;
 
     sv = sv_2mortal(new_version(sv));
+
+    {
+        req = SvRV(sv);
+        pv = *hv_fetchs(MUTABLE_HV(req), "original", FALSE);
+
+	    str_version = SvPVx_nolen_const(pv);
+	    ptr = str_version;
+	    if (*str_version == 'v') ++ptr;
+
+	    switch ( *ptr ) {
+	        case '1':
+	        case '2':
+	        case '3':
+	        case '4':
+	        case '5':
+	            break;
+	        case '6':
+	            DIE(aTHX_ "'use %s' is not supported by Perl 7", str_version );
+	            break;
+	        case '7':
+	            /* use 7* is not supported */
+	            if (ptr == str_version || strlen(ptr) != 1)
+                    DIE(aTHX_ "use v7; is the only supported syntax for Perl 7." );
+	            RETPUSHYES;
+	            break;
+	        default:
+	            DIE(aTHX_ "Unknown behavior for 'use %s'", str_version );
+	    }
+    }
+
+    /* catch issues like use 5.6 which converts to 5.600 instead of using 5.006 */
+    sv_last_five_version = sv_2mortal(upg_version(newSVnv(5.033000), FALSE)); /* the last available release version */
+
     if (!Perl_sv_derived_from_pvn(aTHX_ PL_patchlevel, STR_WITH_LEN("version"), 0))
         upg_version(PL_patchlevel, TRUE);
+
     if (cUNOP->op_first->op_type == OP_CONST && cUNOP->op_first->op_private & OPpCONST_NOVER) {
-        if ( vcmp(sv,PL_patchlevel) <= 0 )
+        /* no 5.000 logic lives here */
+        if ( vcmp(sv,sv_last_five_version) <= 0 )
             DIE(aTHX_ "Perls since %" SVf " too modern--this is %" SVf ", stopped",
                 SVfARG(sv_2mortal(vnormal(sv))),
                 SVfARG(sv_2mortal(vnormal(PL_patchlevel)))
             );
     }
     else {
-        if ( vcmp(sv,PL_patchlevel) > 0 ) {
+        if ( vcmp(sv,sv_last_five_version) >= 0 ) {
             I32 first = 0;
             AV *lav;
-            SV * const req = SvRV(sv);
-            SV * const pv = *hv_fetchs(MUTABLE_HV(req), "original", FALSE);
 
             /* get the left hand term */
             lav = MUTABLE_AV(SvRV(*hv_fetchs(MUTABLE_HV(req), "version", FALSE)));

--- a/t/comp/require.t
+++ b/t/comp/require.t
@@ -80,7 +80,7 @@ print "# $@\nnot " if $@;
 print "ok ",$i++," - require v5 ignores sub named v5\n";
 
 eval { require 10.0.2; };
-print "# $@\nnot " unless $@ =~ /^Perl v10\.0\.2 required/;
+print "# $@\nnot " unless $@ =~ qr{\QPerl v10.0.2 required\E};
 print "ok ",$i++," - require 10.0.2\n";
 
 my $ver = 5.005_63;
@@ -91,12 +91,12 @@ print "ok ",$i++," - require 5.005_63\n";
 # check inaccurate fp
 $ver = 10.2;
 eval { require $ver; };
-print "# $@\nnot " unless $@ =~ /^Perl v10\.200.0 required/;
-print "ok ",$i++," - require 10.2\n";
+print "# $@\nnot " unless $@ =~ qr{\QPerl v10.200.0 require\E};
+print "ok ",$i++," - require 10.2 $@\n";
 
 $ver = 10.000_02;
 eval { require $ver; };
-print "# $@\nnot " unless $@ =~ /^Perl v10\.0\.20 required/;
+print "# $@\nnot " unless $@ =~ qr{\QPerl v10.0.20 required\E};
 print "ok ",$i++," - require 10.000_02\n";
 
 print "not " unless 5.5.1 gt v5.5;

--- a/t/lib/feature/implicit
+++ b/t/lib/feature/implicit
@@ -58,6 +58,8 @@ Helloworld
 # no implicit features with 'no'
 eval "no " . ($]+1); print $@;
 EXPECT
+OPTIONS regex
+Unknown behavior for .*
 ########
 # lower version after higher version
 sub evalbytes { print "evalbytes sub\n" }

--- a/t/porting/diag.t
+++ b/t/porting/diag.t
@@ -718,6 +718,9 @@ Wrong size of loadOrdinals array: expected %d, actual %d
 Wrong syntax (suid) fd script name "%s"
 'X' outside of string in %s
 'X' outside of string in unpack
+'use %s' is not supported by Perl 7
+Unknown behavior for 'use %s'
+use v7; is the only supported syntax for Perl 7.
 
 __CATEGORIES__
 


### PR DESCRIPTION
This is restoring the expected behavior for 'use 5.x'

And also blocks from using Perl 5 version higher than 5.32.255
Use 6 or v6 is blocked.

For now 'use v7' is the only supported syntax.

Relates: #187 