### PR TITLE
hints files:  Relax strict vars

### DIFF
--- a/cpan/DB_File/hints/bitrig.pl
+++ b/cpan/DB_File/hints/bitrig.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/cpan/DB_File/hints/dynixptx.pl
+++ b/cpan/DB_File/hints/dynixptx.pl
@@ -1,3 +1,3 @@
 # Need to add an extra '-lc' to the end to work around a DYNIX/ptx bug
-
+no strict 'vars';
 $self->{LIBS} = ['-lm -lc'];

--- a/cpan/DB_File/hints/minix.pl
+++ b/cpan/DB_File/hints/minix.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/cpan/DB_File/hints/netbsd.pl
+++ b/cpan/DB_File/hints/netbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/cpan/DB_File/hints/sco.pl
+++ b/cpan/DB_File/hints/sco.pl
@@ -1,2 +1,3 @@
 # osr5 needs to explicitly link against libc to pull in some static symbols
+no strict 'vars';
 $self->{LIBS} = ['-ldb -lc'] if $Config{'osvers'} =~ '3\.2v5\.0\..' ;

--- a/cpan/Digest-MD5/hints/MacOS.pl
+++ b/cpan/Digest-MD5/hints/MacOS.pl
@@ -1,3 +1,3 @@
 # MWCPPC compiler needs to crank down the optimizations
-
+no strict 'vars';
 $self->{MWCPPCOptimize} = "-O1";

--- a/cpan/Digest-MD5/hints/dec_osf.pl
+++ b/cpan/Digest-MD5/hints/dec_osf.pl
@@ -1,3 +1,4 @@
+no strict 'vars';
 if ($] < 5.00503 and !$Config{gccversion}) {
   print "
   Because of a bug with the DEC system C compiler, some tests in

--- a/cpan/Digest-MD5/hints/irix_6.pl
+++ b/cpan/Digest-MD5/hints/irix_6.pl
@@ -1,6 +1,6 @@
 # The Mongoose v7.1 compiler freezes up somewhere in the optimization of
 # MD5Transform() in MD5.c with optimization -O3.  This is a workaround:
-
+no strict 'vars';
 if ($Config{cc} =~ /64|n32/ && `$Config{cc} -version 2>&1` =~ /\s7\.1/) {
     $self->{OPTIMIZE} = "-O1";
 }

--- a/cpan/IPC-SysV/hints/next_3.pl
+++ b/cpan/IPC-SysV/hints/next_3.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -D_POSIX_SOURCE' ;

--- a/dist/IO/hints/sco.pl
+++ b/dist/IO/hints/sco.pl
@@ -1,2 +1,3 @@
 # SCO OSR5 needs to link with libc.so again to have C<fsync> defined
+no strict 'vars';
 $self->{LIBS} = ['-lc'];

--- a/dist/Storable/hints/gnukfreebsd.pl
+++ b/dist/Storable/hints/gnukfreebsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/dist/Storable/hints/gnuknetbsd.pl
+++ b/dist/Storable/hints/gnuknetbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/dist/Storable/hints/hpux.pl
+++ b/dist/Storable/hints/hpux.pl
@@ -1,6 +1,6 @@
 # HP C-ANSI-C has problems in the optimizer for 5.8.x (not for 5.11.x)
 # So drop to -O1 for Storable
-
+no strict 'vars';
 use Config;
 
 unless ($Config{gccversion}) {

--- a/dist/Time-HiRes/hints/aix.pl
+++ b/dist/Time-HiRes/hints/aix.pl
@@ -1,5 +1,6 @@
 # Many AIX installations seem not to have the right PATH
 # for the C compiler.  Steal the logic from Perl's hints/aix.sh.
+no strict 'vars';
 use Config;
 unless ($Config{gccversion}) {
     my $cc = $Config{cc};

--- a/dist/Time-HiRes/hints/dec_osf.pl
+++ b/dist/Time-HiRes/hints/dec_osf.pl
@@ -1,3 +1,4 @@
 # needs to explicitly link against librt to pull in nanosleep
+no strict 'vars';
 $self->{LIBS} = ['-lrt'];
 

--- a/dist/Time-HiRes/hints/dynixptx.pl
+++ b/dist/Time-HiRes/hints/dynixptx.pl
@@ -1,5 +1,6 @@
 # uname -v
 # V4.5.2
 # needs to explicitly link against libc to pull in usleep
+no strict 'vars';
 $self->{LIBS} = ['-lc'];
 

--- a/dist/Time-HiRes/hints/irix.pl
+++ b/dist/Time-HiRes/hints/irix.pl
@@ -1,3 +1,4 @@
+no strict 'vars';
 use Config;
 if ($Config{osvers} == 5) {
   $self->{CCFLAGS} = $Config{ccflags};

--- a/dist/Time-HiRes/hints/sco.pl
+++ b/dist/Time-HiRes/hints/sco.pl
@@ -1,4 +1,5 @@
 # osr5 needs to explicitly link against libc to pull in usleep
 # what's the reason for -lm?
+no strict 'vars';
 $self->{LIBS} = ['-lm', '-lc'];
 

--- a/dist/Time-HiRes/hints/solaris.pl
+++ b/dist/Time-HiRes/hints/solaris.pl
@@ -1,4 +1,5 @@
 # 2.6 has nanosleep in -lposix4, after that it's in -lrt
+no strict 'vars';
 my $r = `/usr/bin/uname -r`;
 chomp($r);
 if (substr($r, 2) <= 6) {

--- a/dist/Time-HiRes/hints/svr4.pl
+++ b/dist/Time-HiRes/hints/svr4.pl
@@ -1,4 +1,5 @@
 # NCR MP-RAS needs to explicitly link against libc to pull in usleep
 # what's the reason for -lm?
+no strict 'vars';
 $self->{LIBS} = ['-lm', '-lc'];
 

--- a/dist/threads/hints/hpux.pl
+++ b/dist/threads/hints/hpux.pl
@@ -1,4 +1,5 @@
 # HP-UX 10.20 has different form for pthread_attr_getstacksize
+no strict 'vars';
 my $ver = `uname -r`;
 $ver =~ s/^\D*//;
 if ($ver =~ /^10.20/) {

--- a/ext/B/hints/darwin.pl
+++ b/ext/B/hints/darwin.pl
@@ -1,4 +1,5 @@
 # gcc -O3 (and -O2) get overly excited over B.c in MacOS X 10.1.4.
+no strict 'vars';
 use Config;
 
 my $optimize = $Config{optimize};

--- a/ext/DynaLoader/hints/aix.pl
+++ b/ext/DynaLoader/hints/aix.pl
@@ -1,4 +1,5 @@
 # See dl_aix.xs for details.
+no strict 'vars';
 use Config;
 if ($Config{libs} =~ /-lC/ && -f '/lib/libC.a') {
     $self->{CCFLAGS} = $Config{ccflags} . ' -DUSE_libC';

--- a/ext/DynaLoader/hints/android.pl
+++ b/ext/DynaLoader/hints/android.pl
@@ -7,5 +7,6 @@
 # use My::Module::In::Foo; # calls dlopen() with foo/My/Module/...
 #                          # which will likely fail
 # So we take this route instead.
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DDLOPEN_WONT_DO_RELATIVE_PATHS';
 1;

--- a/ext/DynaLoader/hints/gnukfreebsd.pl
+++ b/ext/DynaLoader/hints/gnukfreebsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/DynaLoader/hints/gnuknetbsd.pl
+++ b/ext/DynaLoader/hints/gnuknetbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/DynaLoader/hints/netbsd.pl
+++ b/ext/DynaLoader/hints/netbsd.pl
@@ -1,3 +1,4 @@
 # XXX Configure test needed?
 # Some NetBSDs seem to have a dlopen() that won't accept relative paths
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DDLOPEN_WONT_DO_RELATIVE_PATHS';

--- a/ext/GDBM_File/hints/sco.pl
+++ b/ext/GDBM_File/hints/sco.pl
@@ -1,2 +1,3 @@
 # SCO OSR5 needs to link with libc.so again to have C<fsync> defined
+no strict 'vars';
 $self->{LIBS} = ['-lgdbm -lc'];

--- a/ext/NDBM_File/hints/MSWin32.pl
+++ b/ext/NDBM_File/hints/MSWin32.pl
@@ -1,2 +1,3 @@
 # uses GDBM dbm compatibility feature
+no strict 'vars';
 $self->{LIBS} = ['-lgdbm_compat -lgdbm'];

--- a/ext/NDBM_File/hints/cygwin.pl
+++ b/ext/NDBM_File/hints/cygwin.pl
@@ -1,2 +1,3 @@
 # uses GDBM ndbm compatibility feature
+no strict 'vars';
 $self->{LIBS} = ['-lgdbm -lgdbm_compat'];

--- a/ext/NDBM_File/hints/dec_osf.pl
+++ b/ext/NDBM_File/hints/dec_osf.pl
@@ -1,2 +1,3 @@
 #   Spider Boardman  <spider@Orb.Nashua.NH.US>
+no strict 'vars';
 $self->{LIBS} = [''];

--- a/ext/NDBM_File/hints/dynixptx.pl
+++ b/ext/NDBM_File/hints/dynixptx.pl
@@ -1,3 +1,4 @@
 # On DYNIX/ptx 4.0 (v4.1.3), ndbm is actually contained in the 
 # libc library, and must be explicitly linked against -lc when compiling.
+no strict 'vars';
 $self->{LIBS} = ['-lc'];

--- a/ext/NDBM_File/hints/gnu.pl
+++ b/ext/NDBM_File/hints/gnu.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/NDBM_File/hints/gnukfreebsd.pl
+++ b/ext/NDBM_File/hints/gnukfreebsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/NDBM_File/hints/gnuknetbsd.pl
+++ b/ext/NDBM_File/hints/gnuknetbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/NDBM_File/hints/sco.pl
+++ b/ext/NDBM_File/hints/sco.pl
@@ -1,4 +1,5 @@
 # SCO ODT 3.2v4.2 has a -ldbm library that is missing dbmclose.  
 # This system should have a complete library installed as -ldbm.nfs which
 # should be used instead (Probably need the networking product add-on)
+no strict 'vars';
 $self->{LIBS} = ['-lndbm',-e "/usr/lib/libdbm.nfs.a"?'-ldbm.nfs':'-ldbm'];

--- a/ext/NDBM_File/hints/solaris.pl
+++ b/ext/NDBM_File/hints/solaris.pl
@@ -1,3 +1,4 @@
 # -lucb has been reported to be fatal for perl5 on Solaris.
 # Thus we deliberately don't include it here.
+no strict 'vars';
 $self->{LIBS} = ["-lndbm", "-ldbm"];

--- a/ext/NDBM_File/hints/svr4.pl
+++ b/ext/NDBM_File/hints/svr4.pl
@@ -1,4 +1,5 @@
 # Some SVR4 systems may need to link against routines in -lucb for
 # odbm.  Some may also need to link against -lc to pick up things like
 # ecvt.
+no strict 'vars';
 $self->{LIBS} = ['-ldbm -lucb -lc'];

--- a/ext/ODBM_File/hints/MSWin32.pl
+++ b/ext/ODBM_File/hints/MSWin32.pl
@@ -1,2 +1,3 @@
 # uses GDBM dbm compatibility feature
+no strict 'vars';
 $self->{LIBS} = ['-lgdbm_compat -lgdbm'];

--- a/ext/ODBM_File/hints/cygwin.pl
+++ b/ext/ODBM_File/hints/cygwin.pl
@@ -1,2 +1,3 @@
 # uses GDBM dbm compatibility feature
+no strict 'vars';
 $self->{LIBS} = ['-lgdbm -lgdbm_compat'];

--- a/ext/ODBM_File/hints/dec_osf.pl
+++ b/ext/ODBM_File/hints/dec_osf.pl
@@ -1,6 +1,7 @@
 # The -hidden option causes compilation to fail on Digital Unix.
 #   Andy Dougherty  <doughera@lafayette.edu>
 #   Sat Jan 13 16:29:52 EST 1996
+no strict 'vars';
 $self->{LDDLFLAGS} = $Config{lddlflags};
 $self->{LDDLFLAGS} =~ s/-hidden//;
 #  As long as we're hinting, note the known location of the dbm routines.

--- a/ext/ODBM_File/hints/gnu.pl
+++ b/ext/ODBM_File/hints/gnu.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/ODBM_File/hints/gnukfreebsd.pl
+++ b/ext/ODBM_File/hints/gnukfreebsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/ODBM_File/hints/gnuknetbsd.pl
+++ b/ext/ODBM_File/hints/gnuknetbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/ODBM_File/hints/hpux.pl
+++ b/ext/ODBM_File/hints/hpux.pl
@@ -1,4 +1,5 @@
 #  Try to work around "bad free" messages.  See note in ODBM_File.xs.
 #   Andy Dougherty  <doughera@lafayette.edu>
 #   Sun Sep  8 12:57:52 EDT 1996
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DDBM_BUG_DUPLICATE_FREE' ;

--- a/ext/ODBM_File/hints/sco.pl
+++ b/ext/ODBM_File/hints/sco.pl
@@ -1,4 +1,5 @@
 # SCO ODT 3.2v4.2 has a -ldbm library that is missing dbmclose.  
 # This system should have a complete library installed as -ldbm.nfs which
 # should be used instead (Probably need the networking product add-on)
+no strict 'vars';
 $self->{LIBS} = ['-lndbm',-e "/usr/lib/libdbm.nfs.a"?'-ldbm.nfs':'-ldbm'];

--- a/ext/ODBM_File/hints/solaris.pl
+++ b/ext/ODBM_File/hints/solaris.pl
@@ -1,3 +1,4 @@
 # -lucb has been reported to be fatal for perl5 on Solaris.
 # Thus we deliberately don't include it here.
+no strict 'vars';
 $self->{LIBS} = ['-ldbm'];

--- a/ext/ODBM_File/hints/svr4.pl
+++ b/ext/ODBM_File/hints/svr4.pl
@@ -1,4 +1,5 @@
 # Some SVR4 systems may need to link against routines in -lucb for
 # odbm.  Some may also need to link against -lc to pick up things like
 # ecvt.
+no strict 'vars';
 $self->{LIBS} = ['-ldbm -lucb -lc'];

--- a/ext/ODBM_File/hints/ultrix.pl
+++ b/ext/ODBM_File/hints/ultrix.pl
@@ -1,4 +1,5 @@
 #  Try to work around "bad free" messages.  See note in ODBM_File.xs.
 #   Andy Dougherty  <doughera@lafayette.edu>
 #   Sun Sep  8 12:57:52 EDT 1996
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DDBM_BUG_DUPLICATE_FREE' ;

--- a/ext/POSIX/hints/bsdos.pl
+++ b/ext/POSIX/hints/bsdos.pl
@@ -1,3 +1,4 @@
 # BSD platforms have extra fields in struct tm that need to be initialized.
 #  XXX A Configure test is needed.
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DSTRUCT_TM_HASZONE' ;

--- a/ext/POSIX/hints/dynixptx.pl
+++ b/ext/POSIX/hints/dynixptx.pl
@@ -1,4 +1,4 @@
 # Need to add an extra '-lc' to the end to work around a DYNIX/ptx bug
 # PR#227670 - linker error on fpgetround()
-
+no strict 'vars';
 $self->{LIBS} = ['-ldb -lm -lc'];

--- a/ext/POSIX/hints/gnukfreebsd.pl
+++ b/ext/POSIX/hints/gnukfreebsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/POSIX/hints/gnuknetbsd.pl
+++ b/ext/POSIX/hints/gnuknetbsd.pl
@@ -1,1 +1,2 @@
+no strict 'vars';
 do './hints/linux.pl' or die $@;

--- a/ext/POSIX/hints/mint.pl
+++ b/ext/POSIX/hints/mint.pl
@@ -1,2 +1,3 @@
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DNO_LOCALECONV_GROUPING -DNO_LOCALECONV_MON_GROUPING';
 

--- a/ext/POSIX/hints/netbsd.pl
+++ b/ext/POSIX/hints/netbsd.pl
@@ -1,3 +1,4 @@
 # BSD platforms have extra fields in struct tm that need to be initialized.
 #  XXX A Configure test is needed.
+no strict 'vars';
 $self->{CCFLAGS} = $Config{ccflags} . ' -DSTRUCT_TM_HASZONE' ;

--- a/ext/POSIX/hints/sunos_4.pl
+++ b/ext/POSIX/hints/sunos_4.pl
@@ -3,7 +3,7 @@
 # This state of affairs also persists in glibc2, found
 # on linux systems running libc6.
 #  XXX A Configure test is needed.
-
+no strict 'vars';
 # Although <unistd.h> is inappropriate in general for SunOS, we need it
 # in POSIX.xs to get the correct prototype for ttyname().
 

--- a/ext/POSIX/hints/svr4.pl
+++ b/ext/POSIX/hints/svr4.pl
@@ -11,6 +11,7 @@
 #  (See hints/svr4.sh for more details.)
 #	A. Dougherty  Tue Oct 30 10:20:07 EST 2001
 #
+no strict 'vars';
 if ($Config{'archname'} =~ /[34]4[0-9][0-9]-svr4/) {
     $self->{LIBS} = ['-lm -posix -lcposix -lmw'];
 }

--- a/ext/PerlIO-via/hints/aix.pl
+++ b/ext/PerlIO-via/hints/aix.pl
@@ -1,4 +1,5 @@
 # compilation may hang at -O3 level
+no strict 'vars';
 use Config;
 
 my $optimize = $Config{optimize};


### PR DESCRIPTION
For: https://github.com/atoomic/perl/issues/251

I wrote a (Perl 7!) program to inspect these hints files and insert `no strict 'vars`;` where it was not already present.

I tested this branch on NetBSD.  All tests PASSed.  I inspected the output of `make test_prep` in locations near where these 3 files would have been processed:
```
$VAR1 = [
  'cpan/DB_File/hints/netbsd.pl',
  'ext/DynaLoader/hints/netbsd.pl',
  'ext/POSIX/hints/netbsd.pl'
];
```
I found no `Variable ... not imported` warnings.

Obviously, until we can get a strict-compliant Perl (7) tested on a wide variety of platforms, we won't be absolutely sure that these revisions are correct.  But they should be good enough for an upcoming Merge Candidate.

Please review.

Thank you very much.
Jim Keenan