### PR TITLE
Issue 191

### DIFF
--- a/dist/Storable/t/tied.t
+++ b/dist/Storable/t/tied.t
@@ -215,15 +215,15 @@ is($FAULT::fault, 2, 'got expected value');
     our ($a, $b);
     $b = "not ok ";
     sub TIESCALAR { bless \$a } sub FETCH { "ok " }
-    no strict 'subs';
-    tie $a, 'P'; my $r = thaw freeze \$a; $b = $$r;
+    tie $a, 'P'; my $r = thaw(freeze(\$a));
+    $b = $$r;
     main::is($b, "ok ", 'thaw freeze got expected value');
 }
 
 {
     # blessed ref to tied object should be thawed blessed
     my @a;
-    { no strict 'subs'; tie @a, TIED_ARRAY; }
+    tie @a, 'TIED_ARRAY';
     my $r = bless \@a, 'FOO99';
     my $f = freeze($r);
     my $t = thaw($f);

--- a/lib/h2xs.t
+++ b/lib/h2xs.t
@@ -51,8 +51,7 @@ if ($^O eq 'VMS') {
         my $drop_dot_notype = $ENV{'DECC$READDIR_DROPDOTNOTYPE'} || '';
         $drop_dot = $drop_dot_notype =~ /^[ET1]/i;
     }
-    no strict 'subs';
-    $Is_VMS_traildot = 0 if $drop_dot && unix_rpt;
+    $Is_VMS_traildot = 0 if $drop_dot && 'unix_rpt';
 }
 if (!(-e $extracted_program)) {
     print "1..0 # Skip: $extracted_program was not built\n";

--- a/t/base/lex.t
+++ b/t/base/lex.t
@@ -99,11 +99,10 @@ E1
 
 my ($bar, %foo, @ary);
 {
-    no strict 'subs';
-    $foo = FOO;
-    $bar = BAR;
-    $foo{$bar} = BAZ;
-    $ary[0] = ABC;
+    $foo = 'FOO';
+    $bar = 'BAR';
+    $foo{$bar} = 'BAZ';
+    $ary[0] = 'ABC';
 }
 
 print "$foo{$bar}" eq "BAZ" ? "ok 21\n" : "not ok 21\n";

--- a/t/comp/fold.t
+++ b/t/comp/fold.t
@@ -123,37 +123,34 @@ is ($@, '', 'no error');
 # [perl #78064] or print
 package other { # hide the "ok" sub
  BEGIN { $^W = 0 }
- print 0 ? "not_ok" : "ok";
+ print 0 ? 'not_ok' : 'ok';
  print " ", ++$test, " - print followed by const ? BEAR : BEAR\n";
- print 1 ? "ok" : "not_ok";
+ print 1 ? 'ok' : 'not_ok';
  print " ", ++$test, " - print followed by const ? BEAR : BEAR (again)\n";
- print 1 && "ok";
+ print 1 && 'ok';
  print " ", ++$test, " - print followed by const && BEAR\n";
- print 0 || "ok";
+ print 0 || 'ok';
  print " ", ++$test, " - print followed by const || URSINE\n";
  BEGIN { $^W = 1 }
 }
 
 # or stat
 {
-    no strict 'subs';
-    print "not " unless stat(1 ? INSTALL : 0) eq stat("INSTALL");
+    print "not " unless stat(1 ? 'INSTALL' : 0) eq stat("INSTALL");
     print "ok ", ++$test, " - stat(const ? word : ....)\n";
     # in case we are in t/
-    print "not " unless stat(1 ? TEST : 0) eq stat("TEST");
+    print "not " unless stat(1 ? 'TEST' : 0) eq stat("TEST");
     print "ok ", ++$test, " - stat(const ? word : ....)\n";
 }
 
 {
     # or truncate
 
-    no strict 'subs';
-    # Per analysis by xenu in https://github.com/Perl/perl5/issues/17996
     my $n = "for_fold_dot_t$$";
     open F, ">$n" or die "open: $!";
     print F "bralh blah blah \n";
     close F or die "close $!";
-    eval "truncate 1 ? $n : 0, 0;";
+    eval "truncate 1 ? '$n' : 0, 0"; # Wrapped '$n', per analysis by xenu in https://github.com/Perl/perl5/issues/17996
     print "not " unless -z $n;
     print "ok ", ++$test, " - truncate(const ? word : ...)\n";
     unlink $n;

--- a/t/op/avhv.t
+++ b/t/op/avhv.t
@@ -113,7 +113,7 @@ not_hash($@);
 # quick check with tied array & tied hash
 my %fake;
 require Tie::Hash;
-{ no strict 'subs'; tie %fake, Tie::StdHash; }
+tie %fake, 'Tie::StdHash';
 %fake = %$sch;
 $a->[0] = \%fake;
 

--- a/t/op/coreamp.t
+++ b/t/op/coreamp.t
@@ -369,7 +369,7 @@ test_proto 'binmode';
 $main::tests += 3;
 is &CORE::binmode(qw[foo bar]), undef, "&binmode";
 lis [&CORE::binmode(qw[foo bar])], [undef], "&binmode in list context";
-{ no strict 'subs'; is &mybinmode(foo), undef, '&binmode with one arg'; }
+is &mybinmode('foo'), undef, '&binmode with one arg';
 
 test_proto 'bless';
 $main::tests += 3;
@@ -455,9 +455,8 @@ lis [&CORE::close('tototootot')], [''], '&close in list context'; ++$main::tests
 test_proto 'closedir';
 $main::tests += 2;
 {
-    no strict 'subs';
-    is &CORE::closedir(foo), undef, '&CORE::closedir';
-    lis [&CORE::closedir(foo)], [undef], '&CORE::closedir in list context';
+    is &CORE::closedir('foo'), undef, '&CORE::closedir';
+    lis [&CORE::closedir('foo')], [undef], '&CORE::closedir in list context';
 }
 
 test_proto 'connect';
@@ -830,14 +829,13 @@ test_proto 'readpipe';
 test_proto 'recv';
 
 {
-    no strict 'subs';
-    use if !is_miniperl, File::Spec::Functions, qw "catfile";
-    use if !is_miniperl, File::Temp, 'tempdir';
+    use if !'is_miniperl', 'File::Spec::Functions', qw "catfile";
+    use if !'is_miniperl', 'File::Temp', 'tempdir';
 }
 
 test_proto 'rename';
 {
-    last if is_miniperl;
+    last if 'is_miniperl';
     $main::tests ++;
     my $dir = tempdir(uc cleanup => 1);
     my $tmpfilenam = catfile $dir, 'aaa';
@@ -1176,11 +1174,11 @@ like $@, qr'^Undefined format "STDOUT" called',
 # haven’t, then either the sub needs to be tested or the list in
 # gv.c is wrong.
 {
-  last if is_miniperl;
+  last if 'is_miniperl';
   require File::Spec::Functions;
   my $keywords_file =
    File::Spec::Functions::catfile(
-      File::Spec::Functions::updir,'regen','keywords.pl'
+      'File::Spec::Functions::updir','regen','keywords.pl'
    );
   my %nottest_words = map { $_ => 1 } qw(
     AUTOLOAD BEGIN CHECK CORE DESTROY END INIT UNITCHECK

--- a/t/op/coresubs.t
+++ b/t/op/coresubs.t
@@ -171,7 +171,7 @@ ok eval { *CORE::exit = \42 },
 inlinable_ok($_, '$_{k}', 'on hash')
     for qw<delete exists>;
 
-{ no strict 'subs'; @UNIVERSAL::ISA = CORE; }
+@UNIVERSAL::ISA = 'CORE';
 is "just another "->ucfirst . "perl hacker,\n"->ucfirst,
    "Just another Perl hacker,\n", 'coresubs do not return TARG';
 ++$tests;

--- a/t/op/current_sub.t
+++ b/t/op/current_sub.t
@@ -11,7 +11,7 @@ is '__SUB__', "__SUB__", '__SUB__ is a bareword outside of use feature';
 
 {
     use v5.15;
-    {no strict 'subs'; is __SUB__, undef, '__SUB__ under use v5.16'; }
+    is __SUB__, undef, '__SUB__ under use v5.16';
 }
 
 use feature 'current_sub';

--- a/t/op/current_sub.t
+++ b/t/op/current_sub.t
@@ -7,7 +7,7 @@ BEGIN {
     plan (tests => 22); # some tests are run in BEGIN block
 }
 
-{no strict 'subs'; is __SUB__, "__SUB__", '__SUB__ is a bareword outside of use feature'; }
+is '__SUB__', "__SUB__", '__SUB__ is a bareword outside of use feature';
 
 {
     use v5.15;

--- a/t/op/defins.t
+++ b/t/op/defins.t
@@ -32,8 +32,7 @@ if ($^O eq 'VMS') {
         my $drop_dot_notype = $ENV{'DECC$READDIR_DROPDOTNOTYPE'} || '';
         $drop_dot = $drop_dot_notype =~ /^[ET1]/i;
     }
-    no strict 'subs';
-    $unix_mode = 1 if $drop_dot && unix_rpt;
+    $unix_mode = 1 if $drop_dot && 'unix_rpt';
 }
 
 # $wanted_filename should be 0 for readdir() and glob() tests.
@@ -56,7 +55,7 @@ print FILE "1\n";
 close(FILE);
 
 open(FILE,"<$saved_filename");
-{ no strict 'subs'; ok(defined(FILE),'opened work file'); }
+ok(defined('FILE'),'opened work file');
 my $seen = 0;
 my $dummy;
 while (my $name = <FILE>)
@@ -98,7 +97,7 @@ cmp_ok($seen,'==',1,'seen in hash while()');
 close FILE;
 
 opendir(DIR,'.');
-{no strict 'subs'; ok(defined(DIR),'opened current directory'); }
+ok(defined('DIR'),'opened current directory');
 $seen = 0;
 while (my $name = readdir(DIR))
  {

--- a/t/op/delete.t
+++ b/t/op/delete.t
@@ -154,10 +154,9 @@ cmp_ok( scalar(@{$refary[0]}),'==',1,'one down');
     my @a = 33;
     my($a) = \(@a);
     my $b = \$a[0];
-    no strict 'subs';
     no warnings 'reserved';
     no warnings 'numeric';
-    my $c = \delete $a[bar];
+    my $c = \delete $a['bar'];
 
     ok($a == $b && $b == $c,'a b c also equivalent');
 }

--- a/t/op/evalbytes.t
+++ b/t/op/evalbytes.t
@@ -29,11 +29,9 @@ is evalbytes($upcode), "\xff\xfe", 'evalbytes on upgraded extra-ASCII';
     is evalbytes($code), "\xff\xfe", 'evalbytes ignores outer utf8 pragma';
 }
 {
-    no strict 'subs';
-
     my $U_100 = byte_utf8a_to_utf8n("\xc4\x80");
-    is evalbytes "use utf8; $U_100", chr 256, 'use utf8 within evalbytes';
-    chop($upcode = "use utf8; $U_100" . chr 256);
+    is evalbytes "use utf8; '$U_100'", chr 256, 'use utf8 within evalbytes';
+    chop($upcode = "use utf8; '$U_100'" . chr 256);
     is evalbytes $upcode, chr 256, 'use utf8 within evalbytes on utf8 string';
     eval { evalbytes chr 256 };
     like $@, qr/Wide character/, 'evalbytes croaks on non-bytes';

--- a/t/op/filetest.t
+++ b/t/op/filetest.t
@@ -263,7 +263,7 @@ for my $op (split //, "rwxoRWXOezsfdlpSbctugkTMBAC") {
 
 # -l and fatal warnings
 stat "test.pl";
-{ no strict 'subs'; eval { use warnings FATAL => io; -l cradd }; }
+eval { use warnings FATAL => 'io'; -l 'cradd' };
 isnt(stat _, 1,
      'fatal warnings do not prevent -l HANDLE from setting stat status');
 
@@ -332,10 +332,10 @@ SKIP: {
 
     # Fatal warnings should not affect the setting of errno.
     $! = 7;
-    -T cradd;
+    -T 'cradd';
     my $errno = $!;
     $! = 7;
-    { no strict 'subs'; eval { use warnings FATAL => unopened; -T cradd }; }
+    eval { use warnings FATAL => 'unopened'; -T 'cradd' };
     my $errno2 = $!;
     is $errno2, $errno,
 	'fatal warnings do not affect errno after -T BADHADNLE';
@@ -361,7 +361,7 @@ SKIP: {
     my $failed_stat1 = stat _;
 
     stat "test.pl";
-    { no strict 'subs'; eval { use warnings FATAL => unopened; -r *phlon }; }
+    eval { use warnings FATAL => 'unopened'; -r *phlon };
     my $failed_stat2 = stat _;
 
     is $failed_stat2, $failed_stat1,
@@ -372,7 +372,7 @@ SKIP: {
     $failed_stat1 = stat _;
 
     stat "test.pl";
-    { no strict 'subs'; eval { use warnings FATAL => unopened; -r cength }; }
+    eval { use warnings FATAL => 'unopened'; -r cength };
     $failed_stat2 = stat _;
     
     is $failed_stat2, $failed_stat1,

--- a/t/op/grep.t
+++ b/t/op/grep.t
@@ -183,7 +183,6 @@ my $test = 0;
     my @list = 0..9;
 
     {
-        no strict 'subs';
         undef $gimme; gimme for @list;      cmp_ok($gimme, 'eq', 'void',   'gimme a V!');
         undef $gimme; grep { gimme } @list; cmp_ok($gimme, 'eq', 'scalar', 'gimme an S!');
         undef $gimme; map { gimme } @list;  cmp_ok($gimme, 'eq', 'list',   'gimme an L!');

--- a/t/op/gv.t
+++ b/t/op/gv.t
@@ -20,7 +20,7 @@ plan(tests => 284);
 # declarators would be missing the point.
 #
 # So we'll run the file with "no strict 'vars'".  We'll also run it with "no
-# strict 'refs'" for similar reasons, but will permit "strict 'subs'" to be on by default and only loosen that stricture when needed.
+# strict 'refs'" for similar reasons, but will permit "strict 'subs'" to be on
 
 no strict 'vars';
 no strict 'refs';
@@ -548,11 +548,11 @@ foreach my $value ({1=>2}, *STDOUT{IO}, *STDOUT{FORMAT}) {
 {
     no warnings qw(once uninitialized);
     my $g = \*clatter;
-    my $r = eval {no strict; ${*{$g}{SCALAR}}};
+    my $r = eval {${*{$g}{SCALAR}}};
     is ($@, '', "PERL_DONT_CREATE_GVSV shouldn't affect thingy syntax");
 
     $g = \*vowm;
-    $r = eval {use strict; ${*{$g}{SCALAR}}};
+    $r = eval {${*{$g}{SCALAR}}};
     is ($@, '',
 	"PERL_DONT_CREATE_GVSV shouldn't affect thingy syntax under strict");
 }
@@ -689,8 +689,7 @@ is join(' ', sub {
 # created for the non-existent function.
 {
 	package RT72740a;
-    no strict 'subs';
-	my $f = bless({}, RT72740b);
+	my $f = bless({}, 'RT72740b');
 	sub s1 { s2 $f; }
 	our $s4;
 	sub s3 { s4 $f; }

--- a/t/op/lexsub.t
+++ b/t/op/lexsub.t
@@ -56,13 +56,12 @@ sub bar::c { 43 }
   is &c, 42, 'our sub foo; makes lex alias for existing sub (amper)';
 }
 {
-  no strict 'subs';
   our sub d;
   sub bar::d { 'd43' }
   package bar;
   sub d { 'd42' }
   my $caution = q|TODO: Use of "strict 'subs'" changes test behavior|;
-  is eval ::d, 'd42', 'our sub foo; applies to subsequent sub foo {}' . " $caution";
+  is eval '::d', 'd42', 'our sub foo; applies to subsequent sub foo {}' . " $caution";
 }
 {
   our sub e ($);
@@ -322,8 +321,7 @@ sub make_anon_with_state_sub{
   state sub BEGIN { exit };
   pass 'state subs are never special blocks';
   state sub END { shift }
-  no strict 'subs';
-  is eval{END('jkqeudth')}, jkqeudth,
+  is eval{END('jkqeudth')}, 'jkqeudth',
     'state sub END {shift} implies @_, not @ARGV';
   state sub CORE { scalar reverse shift }
   is CORE::uc("hello"), "HELLO",
@@ -663,8 +661,7 @@ sub make_anon_with_my_sub{
   my sub BEGIN { exit };
   pass 'my subs are never special blocks';
   my sub END { shift }
-  no strict 'subs';
-  is END('jkqeudth'), jkqeudth,
+  is END('jkqeudth'), 'jkqeudth',
     'my sub END {shift} implies @_, not @ARGV';
 }
 {

--- a/t/op/lop.t
+++ b/t/op/lop.t
@@ -64,18 +64,16 @@ is( $i, 11, 'negation precedence with &&, multiple operands' );
 {
     $x = 42;
 
-    no strict 'subs';
-
-    $i = !Bare || !$x;
+    $i = !'Bare' || !$x;
     is( $i, '', 'neg-bareword on lhs of || with non-foldable neg-true on rhs' );
 
-    $i = !Bare && !$x;
+    $i = !'Bare' && !$x;
     is( $i, '', 'neg-bareword on lhs of && with non-foldable neg-true on rhs' );
 
-    $i = do { !$x if !Bare };
+    $i = do { !$x if !'Bare' };
     is( $i, '', 'neg-bareword on rhs of modifier-if with non-foldable neg-true on lhs' );
 
-    $i = do { !$x unless !Bare };
+    $i = do { !$x unless !'Bare' };
     is( $i, '', 'neg-bareword on rhs of modifier-unless with non-foldable neg-true on lhs' );
 
     $i = !do { "str" } || !$x;

--- a/t/op/pos.t
+++ b/t/op/pos.t
@@ -97,11 +97,10 @@ sub {
 }->($h{k}, $h{l}, $h{m}, $h{n});
 
 {
-    no strict 'subs';
     $x = bless [], chr 256;
     pos $x=1;
     no warnings 'reserved';
-    bless $x, a;
+    bless $x, 'a';
     is pos($x), 1, 'pos is not affected by reference stringification changing';
 }
 
@@ -117,10 +116,9 @@ sub {
 }
 $x = bless [], chr 256;
 {
-    no strict 'subs';
     no warnings 'reserved';
     $x =~ /.(?{
-         bless $x, a;
+         bless $x, 'a';
          is pos($x), 1, 'pos unaffected by ref str changing (in re-eval)';
     })/;
 }

--- a/t/op/runlevel.t
+++ b/t/op/runlevel.t
@@ -37,8 +37,7 @@ sub FETCH {
 }
 package main;
 my $bar = '';
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 print "- $bar\n";
 EXPECT
 still in fetch
@@ -59,8 +58,7 @@ sub FETCH {
  
 package main;
 my $bar = '';
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 print "- $bar\n";
 print "OK\n";
 EXPECT
@@ -83,8 +81,7 @@ eval('die("test\n")');
 package main;
  
 open FH, ">&STDOUT";
-no strict 'subs';
-tie *FH, TEST;
+tie *FH, 'TEST';
 print FH "OK\n";
 print STDERR "DONE\n";
 EXPECT
@@ -115,8 +112,7 @@ sub str {
  
 package main;
  
-no strict 'subs';
-my $bar = bless {}, TEST;
+my $bar = bless {}, 'TEST';
 print "$bar\n";
 print "OK\n";
 EXPECT
@@ -190,8 +186,7 @@ sub STORE {
  
 package main;
 my $bar = '';
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 {
   print "- $bar\n";
 }
@@ -212,8 +207,7 @@ sub FETCH {
  
 package main;
 my $bar = '';
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 print "- $bar\n";
 exit;
 bbb:
@@ -243,8 +237,7 @@ sub STORE {
 }
 package main;
 my $bar = '';
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 $bar = "x";
 ########
 package TEST;
@@ -256,8 +249,7 @@ sub TIESCALAR {
 package main;
 my $bar = '';
 {
-no strict 'subs';
-tie $bar, TEST;
+tie $bar, 'TEST';
 }
 EXPECT
 Can't "next" outside a loop block at - line 4.
@@ -316,11 +308,10 @@ EXPECT
 foo|fee|fie|foe
 ########
 package TH;
-no strict 'subs';
-sub TIEHASH { bless {}, TH }
+sub TIEHASH { bless {}, 'TH' }
 sub STORE { eval { print "@_[1,2]\n" }; die "bar\n" }
 my %h;
-tie %h, TH;
+tie %h, 'TH';
 eval { $h{A} = 1; print "never\n"; };
 print $@;
 eval { $h{B} = 2; };

--- a/t/op/svleak.t
+++ b/t/op/svleak.t
@@ -376,8 +376,7 @@ package t {
 }
 leak(2, 0, sub {
     my $h = {};
-    no strict 'subs';
-    tie %$h, t;
+    tie %$h, 't';
     each %$h;
     undef $h;
 }, 'tied hash iteration does not leak');
@@ -511,7 +510,6 @@ leak(5, 0, sub { scalar &const_av_xsub_leaked }, "const_av_sub in scalar context
 # check that OP_MULTIDEREF doesn't leak when compiled and then freed
 
 eleak(2, 0, <<'EOF', 'OP_MULTIDEREF');
-no strict;
 no warnings;
 my ($x, @a, %h, $r, $k, $i);
 $x = $a[0]{foo}{$k}{$i};

--- a/t/op/taint.t
+++ b/t/op/taint.t
@@ -1539,7 +1539,6 @@ SKIP: {
     SKIP: {
         skip "shm*() not available", 1 unless $Config{d_shm};
 
-        no strict 'subs';
         my $sent = "foobar";
         my $rcvd;
         my $size = 2000;
@@ -1576,7 +1575,6 @@ SKIP: {
     SKIP: {
         skip "msg*() not available", 1 unless $Config{d_msg};
 
-	no strict 'subs';
         my $id;
         eval {
             local $SIG{SYS} = sub { die "SIGSYS caught\n" };

--- a/t/op/warn.t
+++ b/t/op/warn.t
@@ -181,9 +181,8 @@ untie $@;
 }
 my $t;
 {
-  no strict 'subs';
-  tie $t, Tie::StdScalar;
-  $t = bless [], o;
+  tie $t, 'Tie::StdScalar';
+  $t = bless [], 'o';
   no strict 'refs';
   local *{ref(tied $t) . "::STORE"} = sub {};
   undef $t;

--- a/t/run/fresh_perl.t
+++ b/t/run/fresh_perl.t
@@ -123,9 +123,9 @@ $_ x 4;}
 EXPECT
 Modification of a read-only value attempted at - line 3.
 ########
-package FOO;no strict 'subs'; sub new {bless {FOO => BAR}};
+package FOO; sub new {bless {FOO => 'BAR'}};
 package main;
-use strict vars;   
+use strict 'vars';   
 my $self = new FOO;
 print $$self{FOO};
 EXPECT
@@ -160,10 +160,9 @@ our $i; sub ShowShell
 }
  
 {
-    no strict 'subs';
-    &ShowShell(&NewShell(beach,Work,"+0+0"));
-    &ShowShell(&NewShell(beach,Work,"+0+0"));
-    &ShowShell(&NewShell(beach,Work,"+0+0"));
+    &ShowShell(&NewShell('beach','Work',"+0+0"));
+    &ShowShell(&NewShell('beach','Work',"+0+0"));
+    &ShowShell(&NewShell('beach','Work',"+0+0"));
 }
 ########
    {
@@ -181,9 +180,8 @@ our $i; sub ShowShell
    }
    
 my @h;
-no strict 'subs';
-eval 'tie @h, FAKEARRAY, fred' ;
-tie @h, FAKEARRAY, fred ;
+eval q{tie @h, 'FAKEARRAY', 'fred'} ;
+tie @h, 'FAKEARRAY', 'fred' ;
 EXPECT
 TIEARRAY FAKEARRAY fred
 TIEARRAY FAKEARRAY fred
@@ -659,8 +657,7 @@ END {
 }
 package Bar;
 sub new {
-    no strict 'subs';
-    my Bar $self = bless [], Bar;
+    my Bar $self = bless [], 'Bar';
     eval '$self';
     return $self;
 }

--- a/t/uni/gv.t
+++ b/t/uni/gv.t
@@ -575,15 +575,13 @@ format =
 {
     {
             package RƬ72740a;
-            no strict 'subs';
-            my $f = bless({}, RƬ72740b);
+            my $f = bless({}, 'RƬ72740b');
             sub s1 { s2 $f; }
             our $s4;
             sub s3 { s4 $f; }
     }
     {
             package RƬ72740b;
-            no strict 'subs';
             sub s2 { "RƬ72740b::s2" }
             sub s4 { "RƬ72740b::s4" }
     }


### PR DESCRIPTION
Removed "no strict 'sub" and "no strict sub" where applicable. Files changed were determined using the following commands. I am sure this is not the complete list, will hunt more down. Please advise.

$ git diff --name-only v5.32.0 | egrep -i '(t|pl)$' | xargs grep -l "no strict sub"
$ git diff --name-only v5.32.0 | egrep -i '(t|pl)$' | xargs grep -l "no strict 'sub"

All tests passed after `make && make test`. Ran into a weird test failure (`dist/Time-HiRes/t/stat.t`) that seemed unrelated and will be tracking down outside of this work since it is probably platform or local environment related.
