### PR TITLE
Jkeenan/warnings t base

### DIFF
--- a/t/base/num.t
+++ b/t/base/num.t
@@ -1,9 +1,16 @@
 #!./perl
 
+BEGIN {
+    chdir 't' if -d 't';
+    @INC = '../lib'; # needed to locate strict for instances of 'no warnings'
+}
+
 print "1..53\n";
 
 # First test whether the number stringification works okay.
 # (Testing with == would exercise the IV/NV part, not the PV.)
+
+no warnings 'void';
 
 my $alpha = 1; "$alpha";
 print $alpha eq "1"       ? "ok 1\n"  : "not ok 1 # $alpha\n";

--- a/t/base/term.t
+++ b/t/base/term.t
@@ -39,9 +39,9 @@ if (($x | 1) == 101) {print "ok 5\n";} else {print "not ok 5\n";}
 
 # check <> pseudoliteral
 
-open(TRY, "/dev/null") || open(TRY,"nla0:") || (die "Can't open /dev/null.");
+open('try', "/dev/null") || open('try',"nla0:") || (die "Can't open /dev/null.");
 
-if (! defined <TRY> or <TRY> eq '') {
+if (! defined <try> or <try> eq '') {
     print "ok 6\n";
 }
 else {
@@ -49,5 +49,5 @@ else {
     die "/dev/null IS NOT A CHARACTER SPECIAL FILE!!!!\n" unless -c '/dev/null';
 }
 
-open(TRY, "harness") || (die "Can't open harness.");
-if (<TRY> ne '') {print "ok 7\n";} else {print "not ok 7\n";}
+open('try', "harness") || (die "Can't open harness.");
+if (<try> ne '') {print "ok 7\n";} else {print "not ok 7\n";}

--- a/t/base/term.t
+++ b/t/base/term.t
@@ -39,9 +39,9 @@ if (($x | 1) == 101) {print "ok 5\n";} else {print "not ok 5\n";}
 
 # check <> pseudoliteral
 
-open(try, "/dev/null") || open(try,"nla0:") || (die "Can't open /dev/null.");
+open(TRY, "/dev/null") || open(TRY,"nla0:") || (die "Can't open /dev/null.");
 
-if (<try> eq '') {
+if (! defined <TRY> or <TRY> eq '') {
     print "ok 6\n";
 }
 else {
@@ -49,5 +49,5 @@ else {
     die "/dev/null IS NOT A CHARACTER SPECIAL FILE!!!!\n" unless -c '/dev/null';
 }
 
-open(try, "harness") || (die "Can't open harness.");
-if (<try> ne '') {print "ok 7\n";} else {print "not ok 7\n";}
+open(TRY, "harness") || (die "Can't open harness.");
+if (<TRY> ne '') {print "ok 7\n";} else {print "not ok 7\n";}


### PR DESCRIPTION
Reviewers:  There's one aspect of this pull request which warrants some discussion.

`perldoc perlhack` advises:
```
   *   t/base, t/comp and t/opbasic

        Since we don't know if "require" works, or even subroutines, use ad
        hoc tests for these three. Step carefully to avoid using the feature
        being tested. Tests in t/opbasic, for instance, have been placed
        there rather than in t/op because they test functionality which
        t/test.pl presumes has already been demonstrated to work.
```
For these 3 subdirectories -- and for `t/base` in particular -- we have tended to write tests on the premise that `require` and `use` have not yet been demonstrated to work.  But if `use MODULE` has not yet been proven to work, then presumably `no MODULE` has also not yet been proven to work.

However, once we run test files in these directories under strict-by-default and/or warnings-by-default, we have to have a way of temporarily relaxing strictures or suppressing warnings.  That suggests judicious, precise use of, say, `no strict 'uninitialized`;' and `no strict 'refs;'`.  But that presumes that we can load modules.

We don't face this problem in Perl 5 because most files in these subdirectories never cared about strictures or warnings.  Indeed, some of them date to Perl 1 in 1987 -- long before strictures and warnings even existed.

See, for example, `t/base/lex.t` (commit d4f1572b203, already in `alpha`) and `t/base/num.t` (commit 3a4795bae1e, in this pull request).

How shall we square this circle?

Thank you very much.
Jim Keenan