### PR TITLE
Jkeenan/warnings t uni

### DIFF
--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -5307,6 +5307,11 @@ a dirhandle.  Check your control flow.
 (W closed) The filehandle you're reading from got itself closed sometime
 before now.  Check your control flow.
 
+=item readline() on unopened filehandle %s
+
+(W unopened) The filehandle you're reading from was never opened.  Check your
+control flow.
+
 =item read() on closed filehandle %s
 
 (W closed) You tried to read from a closed filehandle.

--- a/t/uni/package.t
+++ b/t/uni/package.t
@@ -25,6 +25,7 @@ ok 1, "sanity check. If we got this far, UTF-8 in package names is legal.";
 {
 
     no strict 'vars';
+    no warnings 'once';
 
     $ㄅĽuṞfⳐ = 123;
     

--- a/t/uni/parser.t
+++ b/t/uni/parser.t
@@ -19,8 +19,11 @@ use open qw( :utf8 :std );
 {
     no strict 'vars';
 
-    is *tèst, "*main::tèst", "sanity check.";
-    ok $::{"tèst"}, "gets the right glob in the stash.";
+    {
+        no warnings 'once';
+        is *tèst, "*main::tèst", "sanity check.";
+        ok $::{"tèst"}, "gets the right glob in the stash.";
+    }
     
     my $glob_by_sub = sub { *ｍａｉｎ::method }->();
     
@@ -36,8 +39,11 @@ use open qw( :utf8 :std );
     }
     
     is "" . gimme_glob("下郎"), "*main::下郎";
-    $a = *下郎;
-    is "" . $a, "*main::下郎";
+    {
+        no warnings 'once';
+        $a = *下郎;
+        is "" . $a, "*main::下郎";
+    }
     
     *{gimme_glob("下郎")} = sub {};
     
@@ -68,17 +74,20 @@ use open qw( :utf8 :std );
         ok $@, q!$c can't call $b's sub.!;
         
         # Now define another sub under the downgraded name:
-        *$a = sub { 6 };
-        # Call it:
-        is eval { main->$a }, 6, "Adding a new sub to *a and calling it works,";
-        ok !$@, "..without errors.";
-        eval { main->$c };
-        ok $@, "but it's still unreachable through *c";
-        
-        *$b = \10;
-        is ${*$a{SCALAR}}, 10;
-        is ${*$b{SCALAR}}, 10;
-        is ${*$c{SCALAR}}, undef;
+        {
+            no warnings 'redefine';
+            *$a = sub { 6 };
+            # Call it:
+            is eval { main->$a }, 6, "Adding a new sub to *a and calling it works,";
+            ok !$@, "..without errors.";
+            eval { main->$c };
+            ok $@, "but it's still unreachable through *c";
+
+            *$b = \10;
+            is ${*$a{SCALAR}}, 10;
+            is ${*$b{SCALAR}}, 10;
+            is ${*$c{SCALAR}}, undef;
+        }
         
         opendir FÒÒ, ".";
         closedir FÒÒ;
@@ -96,10 +105,10 @@ use open qw( :utf8 :std );
         is grep({ $_ eq "\345\216\237" } keys %::), 0;
         
         #These should probably go elsewhere.
-        eval q{ sub wròng1 (_$); wròng1(1,2) };
+        eval q{ no warnings 'illegalproto'; sub wròng1 (_$); wròng1(1,2) };
         like( $@, qr/Malformed prototype for main::wròng1/, 'Malformed prototype croak is clean.' );
         
-        eval q{ sub ча::ики ($__); ча::ики(1,2) };
+        eval q{ no warnings 'illegalproto'; sub ча::ики ($__); ча::ики(1,2) };
         like( $@, qr/Malformed prototype for ча::ики/ );
         
         our $問 = 10;
@@ -139,7 +148,7 @@ use open qw( :utf8 :std );
 
         $f = qq{(?{q\0foobar\0 \x{FFFF}+1 })};
         eval { "a" =~ /^a$f/ };
-        my $e = $@;
+        $e = $@;
         $e =~ s/eval \d+/eval 11/;
         is(
             $e,
@@ -166,6 +175,8 @@ use open qw( :utf8 :std );
     use feature 'state';
     for ( qw( my state our ) ) {
         local $@;
+        no warnings 'once';
+        no warnings 'uninitialized';
         eval "$_ Ｆｏｏ $x = 1;";
         like $@, qr/No such class Ｆｏｏ/u, "'No such class' warning for $_ is UTF-8 clean";
     }
@@ -270,6 +281,7 @@ SKIP: {
 }
 
 no strict 'refs';
+no warnings 'uninitialized';
 fresh_perl_is(<<'EOS', <<'EXPECT', {}, 'no panic in pad_findmy_pvn (#134061)');
 use utf8;
 eval "sort \x{100}%";

--- a/t/uni/readline.t
+++ b/t/uni/readline.t
@@ -14,7 +14,7 @@ use open qw( :utf8 :std );
 # [perl #19566]: sv_gets writes directly to its argument via
 # TARG. Test that we respect SvREADONLY.
 use constant roref=>\2;
-eval { for (roref) { $_ = <Fʜ> } };
+eval { no warnings 'once'; no warnings 'unopened'; for (roref) { $_ = <Fʜ> } };
 like($@, qr/Modification of a read-only value attempted/, '[perl #19566]');
 
 # [perl #21628]
@@ -23,10 +23,9 @@ like($@, qr/Modification of a read-only value attempted/, '[perl #19566]');
   open Ạ,'+>',$file; $a = 3;
   is($a .= <Ạ>, 3, '#21628 - $a .= <A> , A eof');
   close Ạ; $a = 4;
-  is($a .= <Ạ>, 4, '#21628 - $a .= <A> , A closed');
+  { no warnings 'closed'; is($a .= <Ạ>, 4, '#21628 - $a .= <A> , A closed'); }
 }
 
-use strict;
 my $err;
 {
   open ᕝ, '.' and binmode ᕝ and sysread ᕝ, $_, 1;

--- a/t/uni/stash.t
+++ b/t/uni/stash.t
@@ -42,14 +42,12 @@ our $TODO;
 #op/stash.t
 {
     package ᛐⲞɲe::Šꇇᚽṙᆂṗ;
+    no warnings 'once';
     $본go::ଶfʦbᚒƴ::scalar = 1;
     
     package main;
         
-    # now tests with strictures
-    
     {
-        use strict;
         ok( !exists $piƓ::{bodine}, q(referencing a non-existent stash element doesn't produce stricture errors) );
     }
 
@@ -95,13 +93,13 @@ our $TODO;
         is( eval { $gv->NAME }, "__ANON__", "...and an __ANON__ name");
         is( eval { $gv->STASH->NAME }, "__ANON__", "...and an __ANON__ stash");
     
-        my $sub = do {
+        $sub = do {
             package ꃖᚢ;
             sub { 1 };
         };
         %ꃖᚢ:: = ();
     
-        my $gv = B::svref_2object($sub)->GV;
+        $gv = B::svref_2object($sub)->GV;
         ok($gv->isa(q/B::GV/), "cleared stash leaves anon CV with valid GV");
     
         my $st = eval { $gv->STASH->NAME };
@@ -152,6 +150,7 @@ our $TODO;
         # on glob reassignment, orphaned CV should have anon CvGV
     
         {
+            no warnings 'redefine';
             my $r;
             eval q[
                 package ＦŌŌ௨;
@@ -237,6 +236,7 @@ our $TODO;
         use Config;
     
         my $obj  = bless [];
+        no warnings 'once';
         my $globref = \*tàt;
     
         # effectively rename a stash
@@ -268,6 +268,7 @@ our $TODO;
     
     # Setting the name during undef %stash:: should have no effect.
     {
+        no warnings 'once';
         my $glob = \*Phòò::glòb;
         sub ò::DESTROY { eval '++$Phòò::bòr' }
         no strict 'refs';

--- a/t/uni/universal.t
+++ b/t/uni/universal.t
@@ -102,12 +102,15 @@ ok (!Cèdrìc->isa('Prògràmmèr'));
 
 my $b = 'abc';
 my @refs = qw(SCALAR SCALAR     LVALUE      GLOB ARRAY HASH CODE);
-my @vals = (  \$b,   \3.14, \substr($b,1,1), \*b,  [],  {}, sub {} );
-for (my $p=0; $p < @refs; $p++) {
-    for (my $q=0; $q < @vals; $q++) {
-        is UNIVERSAL::isa($vals[$p], $refs[$q]), ($p==$q or $p+$q==1);
+{
+    no warnings 'once';
+    my @vals = (  \$b,   \3.14, \substr($b,1,1), \*b,  [],  {}, sub {} );
+    for (my $p=0; $p < @refs; $p++) {
+        for (my $q=0; $q < @vals; $q++) {
+            is UNIVERSAL::isa($vals[$p], $refs[$q]), ($p==$q or $p+$q==1);
+        };
     };
-};
+}
 
 
 ok UNIVERSAL::isa(Àlìcè => "UNIVERSAL");
@@ -137,6 +140,10 @@ ok( ! Bàz->DOES( 'Fòò' ), '... returning true or false appropriately' );
 package Pìg;
 package Bòdìnè;
 Bòdìnè->isa('Pìg');
+
+package zlòpp;
+
+package plòp;
 
 package main;
 eval { UNIVERSAL::DOES([], "fòò") };

--- a/t/uni/upper.t
+++ b/t/uni/upper.t
@@ -11,7 +11,7 @@ use feature 'unicode_strings';
 
 is(uc("\x{3B1}\x{345}\x{301}"), "\x{391}\x{301}\x{399}",
                                                    'Verify moves YPOGEGRAMMENI');
-fresh_perl_is('use 5.026;m.\U00ÿÿ0000.', "", {}, "[perl #133876]  This caused valgrind and asan errors");
+fresh_perl_is('use 5.026; no warnings q|uninitialized|; m.\U00ÿÿ0000.', "", {}, "[perl #133876]  This caused valgrind and asan errors");
 
 casetest( 2,	# extra tests already run
 	"Uppercase_Mapping",


### PR DESCRIPTION
This p.r. should bring `t/uni/*.t` into compliance with warnings-by-default.  Though the overall diff is not that big (IMO), there were a lot of edge cases that had to be flushed out.