### PR TITLE
Issue #245 study changes t/re for strict on by default.

### DIFF
--- a/t/re/speed.t
+++ b/t/re/speed.t
@@ -26,7 +26,6 @@ skip_all_without_unicode_tables();
 
 plan tests => 59;  #** update watchdog timeouts proportionally when adding tests
 
-use strict;
 use warnings;
 use 5.010;
 

--- a/t/re/user_prop_race_thr.t
+++ b/t/re/user_prop_race_thr.t
@@ -13,7 +13,6 @@ require threads;
 {
     fresh_perl_is('
         use threads;
-        use strict;
         use warnings;
 
         sub main::IsA {
@@ -48,7 +47,6 @@ require threads;
 {
     fresh_perl_is('
         use threads;
-        use strict;
         use warnings;
 
         sub InLongSleep {
@@ -87,7 +85,6 @@ require threads;
 {
     fresh_perl_like('
         use threads;
-        use strict;
         use warnings;
 
         sub InLongSleep {


### PR DESCRIPTION
speed.t and user_prop_race_thr had a few strictures specified. both pass without them.