### PR TITLE
ext/: Remove remaining instances of leading 'use strict;'.

### DIFF
--- a/ext/Amiga-ARexx/ARexx.pm
+++ b/ext/Amiga-ARexx/ARexx.pm
@@ -1,7 +1,7 @@
 package Amiga::ARexx;
 
 use 5.016000;
-use strict;
+
 use warnings;
 use Carp;
 
@@ -118,7 +118,7 @@ sub DoRexx($$)
 
 package Amiga::ARexx::Msg;
 
-use strict;
+
 use warnings;
 use Carp;
 

--- a/ext/Amiga-ARexx/__examples/simplecommand.pl
+++ b/ext/Amiga-ARexx/__examples/simplecommand.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Amiga::ARexx qw(DoRexx);

--- a/ext/Amiga-ARexx/__examples/simplehost.pl
+++ b/ext/Amiga-ARexx/__examples/simplehost.pl
@@ -2,7 +2,7 @@
 
 # Simple ARExx Host
 
-use strict;
+
 use Amiga::ARexx;
 use feature "switch";
 

--- a/ext/Amiga-Exec/Exec.pm
+++ b/ext/Amiga-Exec/Exec.pm
@@ -1,7 +1,7 @@
 package Amiga::Exec;
 
 use 5.016000;
-use strict;
+
 use warnings;
 use Carp;
 

--- a/ext/Amiga-Exec/__examples/simplecommand.pl
+++ b/ext/Amiga-Exec/__examples/simplecommand.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Amiga::ARexx qw(DoRexx);

--- a/ext/Amiga-Exec/__examples/simplehost.pl
+++ b/ext/Amiga-Exec/__examples/simplehost.pl
@@ -2,7 +2,7 @@
 
 # Simple ARExx Host
 
-use strict;
+
 use Amiga::ARexx;
 use feature "switch";
 

--- a/ext/B/B/Showlex.pm
+++ b/ext/B/B/Showlex.pm
@@ -2,7 +2,7 @@ package B::Showlex;
 
 our $VERSION = '1.05';
 
-use strict;
+
 use B qw(svref_2object comppadlist class);
 use B::Terse ();
 use B::Concise ();

--- a/ext/B/B/Terse.pm
+++ b/ext/B/B/Terse.pm
@@ -2,7 +2,7 @@ package B::Terse;
 
 our $VERSION = '1.09';
 
-use strict;
+
 use B qw(class @specialsv_name);
 use B::Concise qw(concise_subref set_style_standard);
 use Carp;

--- a/ext/B/B/Xref.pm
+++ b/ext/B/B/Xref.pm
@@ -140,7 +140,7 @@ Malcolm Beattie, mbeattie@sable.ox.ac.uk.
 
 =cut
 
-use strict;
+
 use Config;
 use B qw(peekop class comppadlist main_start svref_2object walksymtable
          OPpLVAL_INTRO SVf_POK SVf_ROK OPpOUR_INTRO cstring

--- a/ext/B/Makefile.PL
+++ b/ext/B/Makefile.PL
@@ -1,7 +1,7 @@
 use ExtUtils::MakeMaker;
 use ExtUtils::Constant 0.23 'WriteConstants';
 use File::Spec;
-use strict;
+
 use warnings;
 
 my $core = grep { $_ eq 'PERL_CORE=1' } @ARGV;

--- a/ext/B/t/OptreeCheck.pm
+++ b/ext/B/t/OptreeCheck.pm
@@ -1,6 +1,6 @@
 package OptreeCheck;
 use parent 'Exporter';
-use strict;
+
 use warnings;
 our ($TODO, $Level, $using_open);
 require "test.pl";

--- a/ext/B/t/b.t
+++ b/ext/B/t/b.t
@@ -11,7 +11,7 @@ BEGIN {
 
 $|  = 1;
 use warnings;
-use strict;
+
 BEGIN  {
     eval { require threads; threads->import; }
 }

--- a/ext/B/t/o.t
+++ b/ext/B/t/o.t
@@ -10,7 +10,7 @@ BEGIN {
 	require 'test.pl';
 }
 
-use strict;
+
 use Config;
 use File::Spec;
 use File::Path;

--- a/ext/B/t/perlstring.t
+++ b/ext/B/t/perlstring.t
@@ -11,7 +11,7 @@ BEGIN {
 
 $|  = 1;
 use warnings;
-use strict;
+
 BEGIN  {
     eval { require threads; threads->import; }
 }

--- a/ext/B/t/pragma.t
+++ b/ext/B/t/pragma.t
@@ -13,7 +13,7 @@ BEGIN {    ## no critic strict
     }
 }
 
-use strict;
+
 use warnings;
 use Test::More tests => 4 * 3;
 use B 'svref_2object';

--- a/ext/B/t/showlex.t
+++ b/ext/B/t/showlex.t
@@ -12,7 +12,7 @@ BEGIN {
 
 $| = 1;
 use warnings;
-use strict;
+
 use Config;
 use B::Showlex ();
 

--- a/ext/B/t/strict.t
+++ b/ext/B/t/strict.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use warnings;
 
 use Config;
@@ -13,7 +13,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use warnings;
 
 use B ();

--- a/ext/B/t/walkoptree.t
+++ b/ext/B/t/walkoptree.t
@@ -10,7 +10,7 @@ BEGIN {
 }
 
 use warnings;
-use strict;
+
 use Test::More;
 
 BEGIN { use_ok( 'B' ); }

--- a/ext/B/t/xref.t
+++ b/ext/B/t/xref.t
@@ -9,7 +9,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use warnings;
 no warnings 'once';
 use Test::More tests => 14;

--- a/ext/DynaLoader/DynaLoader_pm.PL
+++ b/ext/DynaLoader/DynaLoader_pm.PL
@@ -1,6 +1,6 @@
 use Config;
 
-use strict;
+
 use warnings;
 
 sub to_string {

--- a/ext/DynaLoader/Makefile.PL
+++ b/ext/DynaLoader/Makefile.PL
@@ -1,4 +1,4 @@
-use strict;
+
 use ExtUtils::MakeMaker;
 
 my $is_mswin    = $^O eq 'MSWin32';

--- a/ext/DynaLoader/t/DynaLoader.t
+++ b/ext/DynaLoader/t/DynaLoader.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -wT
 
-use strict;
+
 use Config;
 push @INC, '.';
 if (-f 't/test.pl') {

--- a/ext/Errno/Errno_pm.PL
+++ b/ext/Errno/Errno_pm.PL
@@ -1,6 +1,6 @@
 use ExtUtils::MakeMaker;
 use Config;
-use strict;
+
 
 our $VERSION = "1.30";
 
@@ -290,7 +290,7 @@ sub write_errno_pm {
 
 package Errno;
 require Exporter;
-use strict;
+
 
 EDQ
 

--- a/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
+++ b/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm
@@ -1,6 +1,6 @@
 #!./perl -w
 package ExtUtils::Miniperl;
-use strict;
+
 require Exporter;
 use ExtUtils::Embed 1.31, qw(xsi_header xsi_protos xsi_body);
 

--- a/ext/Fcntl/Fcntl.pm
+++ b/ext/Fcntl/Fcntl.pm
@@ -55,7 +55,7 @@ See L<perlfunc/stat> about the S_I* constants.
 
 =cut
 
-use strict;
+
 our($VERSION, @ISA, @EXPORT, @EXPORT_OK, %EXPORT_TAGS);
 
 require Exporter;

--- a/ext/Fcntl/t/autoload.t
+++ b/ext/Fcntl/t/autoload.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 
 require Fcntl;

--- a/ext/Fcntl/t/syslfs.t
+++ b/ext/Fcntl/t/syslfs.t
@@ -12,7 +12,7 @@ BEGIN {
 	require Fcntl; import Fcntl qw(/^O_/ /^SEEK_/);
 }
 
-use strict;
+
 use File::Temp 'tempfile';
 use Test::More;
 

--- a/ext/File-DosGlob/lib/File/DosGlob.pm
+++ b/ext/File-DosGlob/lib/File/DosGlob.pm
@@ -7,7 +7,7 @@
 package File::DosGlob;
 
 our $VERSION = '1.12';
-use strict;
+
 use warnings;
 
 require XSLoader;

--- a/ext/File-Find/lib/File/Find.pm
+++ b/ext/File-Find/lib/File/Find.pm
@@ -1,6 +1,6 @@
 package File::Find;
 use 5.006;
-use strict;
+
 use warnings;
 use warnings::register;
 our $VERSION = '1.37';
@@ -11,7 +11,7 @@ our @ISA = qw(Exporter);
 our @EXPORT = qw(find finddepth);
 
 
-use strict;
+
 my $Is_VMS = $^O eq 'VMS';
 my $Is_Win32 = $^O eq 'MSWin32';
 

--- a/ext/File-Find/t/find.t
+++ b/ext/File-Find/t/find.t
@@ -1,5 +1,5 @@
 #!./perl
-use strict;
+
 use Cwd;
 
 my $warn_msg;

--- a/ext/File-Find/t/lib/Testing.pm
+++ b/ext/File-Find/t/lib/Testing.pm
@@ -1,6 +1,6 @@
 package Testing;
 use 5.006_001;
-use strict;
+
 use warnings;
 require Exporter;
 our @ISA = qw(Exporter);

--- a/ext/File-Find/t/taint.t
+++ b/ext/File-Find/t/taint.t
@@ -1,5 +1,5 @@
 #!./perl -T
-use strict;
+
 use Test::More;
 BEGIN {
     plan(

--- a/ext/File-Glob/Glob.pm
+++ b/ext/File-Glob/Glob.pm
@@ -1,6 +1,6 @@
 package File::Glob;
 
-use strict;
+
 our($VERSION, @ISA, @EXPORT_OK, @EXPORT_FAIL, %EXPORT_TAGS, $DEFAULT_FLAGS);
 
 require XSLoader;

--- a/ext/File-Glob/t/basic.t
+++ b/ext/File-Glob/t/basic.t
@@ -9,7 +9,7 @@ BEGIN {
         exit 0;
     }
 }
-use strict;
+
 use Test::More tests => 49;
 BEGIN {use_ok('File::Glob', ':glob')};
 use Cwd ();

--- a/ext/File-Glob/t/rt114984.t
+++ b/ext/File-Glob/t/rt114984.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 use v5.16.0;
 use File::Temp 'tempdir';

--- a/ext/File-Glob/t/rt131211.t
+++ b/ext/File-Glob/t/rt131211.t
@@ -3,7 +3,7 @@
 # non-matching glob("a*a*a*...") went exponential time on number of a*'s
 
 
-use strict;
+
 use warnings;
 use v5.16.0;
 use File::Temp 'tempdir';

--- a/ext/File-Glob/t/threads.t
+++ b/ext/File-Glob/t/threads.t
@@ -9,7 +9,7 @@ BEGIN {
         exit 0;
     }
 }
-use strict;
+
 use warnings;
 # Test::More needs threads pre-loaded
 use if $Config{useithreads}, 'threads';

--- a/ext/FileCache/lib/FileCache.pm
+++ b/ext/FileCache/lib/FileCache.pm
@@ -85,7 +85,7 @@ so you may have to set I<maxopen> yourself.
 
 require 5.006;
 use Carp;
-use strict;
+
 no strict 'refs';
 
 # These are not C<my> for legacy reasons.

--- a/ext/GDBM_File/GDBM_File.pm
+++ b/ext/GDBM_File/GDBM_File.pm
@@ -57,7 +57,7 @@ L<perl(1)>, L<DB_File(3)>, L<perldbmfilter>.
 
 package GDBM_File;
 
-use strict;
+
 use warnings;
 our($VERSION, @ISA, @EXPORT);
 

--- a/ext/GDBM_File/t/fatal.t
+++ b/ext/GDBM_File/t/fatal.t
@@ -7,7 +7,7 @@
 # releases of the gdbm library, which uses mmap() rather than write() etc:
 # so skip in that case.
 
-use strict;
+
 
 use Test::More;
 use Config;

--- a/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
+++ b/ext/Hash-Util-FieldHash/lib/Hash/Util/FieldHash.pm
@@ -1,7 +1,7 @@
 package Hash::Util::FieldHash;
 
 use 5.009004;
-use strict;
+
 use warnings;
 use Scalar::Util qw( reftype);
 

--- a/ext/Hash-Util-FieldHash/t/12_hashwarn.t
+++ b/ext/Hash-Util-FieldHash/t/12_hashwarn.t
@@ -3,7 +3,7 @@ use Test::More;
 
 plan( tests => 12 );
 
-use strict;
+
 use warnings;
 use Hash::Util::FieldHash qw( :all);
 

--- a/ext/Hash-Util/lib/Hash/Util.pm
+++ b/ext/Hash-Util/lib/Hash/Util.pm
@@ -1,7 +1,7 @@
 package Hash::Util;
 
 require 5.007003;
-use strict;
+
 use Carp;
 use warnings;
 no warnings 'uninitialized';

--- a/ext/Hash-Util/t/Util.t
+++ b/ext/Hash-Util/t/Util.t
@@ -11,7 +11,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use Test::More;
 
 sub numbers_first { # Sort helper: All digit entries sort in front of others

--- a/ext/Hash-Util/t/builtin.t
+++ b/ext/Hash-Util/t/builtin.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -Tw
 
-use strict;
+
 use Test::More;
 
 my @Exported_Funcs;

--- a/ext/I18N-Langinfo/Langinfo.pm
+++ b/ext/I18N-Langinfo/Langinfo.pm
@@ -1,7 +1,7 @@
 package I18N::Langinfo;
 
 use 5.006;
-use strict;
+
 use warnings;
 use Carp;
 

--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -1,5 +1,5 @@
 #!perl -T
-use strict;
+
 use Config;
 use Test::More;
 require "../../t/loc_tools.pl";

--- a/ext/IPC-Open3/lib/IPC/Open2.pm
+++ b/ext/IPC-Open3/lib/IPC/Open2.pm
@@ -1,6 +1,6 @@
 package IPC::Open2;
 
-use strict;
+
 our ($VERSION, @ISA, @EXPORT);
 
 require 5.000;

--- a/ext/IPC-Open3/lib/IPC/Open3.pm
+++ b/ext/IPC-Open3/lib/IPC/Open3.pm
@@ -1,6 +1,6 @@
 package IPC::Open3;
 
-use strict;
+
 no strict 'refs'; # because users pass me bareword filehandles
 our ($VERSION, @ISA, @EXPORT);
 

--- a/ext/IPC-Open3/t/IPC-Open2.t
+++ b/ext/IPC-Open3/t/IPC-Open2.t
@@ -14,7 +14,7 @@ BEGIN {
     $SIG{__WARN__} = sub { die @_ };
 }
 
-use strict;
+
 use IPC::Open2;
 use Test::More tests => 15;
 

--- a/ext/IPC-Open3/t/IPC-Open3.t
+++ b/ext/IPC-Open3/t/IPC-Open3.t
@@ -13,7 +13,7 @@ BEGIN {
     $SIG{__WARN__} = sub { die @_ };
 }
 
-use strict;
+
 use Test::More tests => 45;
 
 use IO::Handle;

--- a/ext/IPC-Open3/t/fd.t
+++ b/ext/IPC-Open3/t/fd.t
@@ -7,7 +7,7 @@ BEGIN {
     }
     require "../../t/test.pl";
 }
-use strict;
+
 use warnings;
 
 plan 3;

--- a/ext/NDBM_File/NDBM_File.pm
+++ b/ext/NDBM_File/NDBM_File.pm
@@ -1,6 +1,6 @@
 package NDBM_File;
 
-use strict;
+
 use warnings;
 
 require Tie::Hash;

--- a/ext/ODBM_File/ODBM_File.pm
+++ b/ext/ODBM_File/ODBM_File.pm
@@ -1,6 +1,6 @@
 package ODBM_File;
 
-use strict;
+
 use warnings;
 
 require Tie::Hash;

--- a/ext/Opcode/Opcode.pm
+++ b/ext/Opcode/Opcode.pm
@@ -2,7 +2,7 @@ package Opcode;
 
 use 5.006_001;
 
-use strict;
+
 
 our($VERSION, @ISA, @EXPORT_OK);
 

--- a/ext/Opcode/t/Opcode.t
+++ b/ext/Opcode/t/Opcode.t
@@ -10,7 +10,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use Test::More;
 
 {

--- a/ext/POSIX/lib/POSIX.pm
+++ b/ext/POSIX/lib/POSIX.pm
@@ -1,5 +1,5 @@
 package POSIX;
-use strict;
+
 use warnings;
 
 our ($AUTOLOAD, %SIGRT);

--- a/ext/POSIX/t/export.t
+++ b/ext/POSIX/t/export.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/POSIX/t/math.t
+++ b/ext/POSIX/t/math.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 
 use POSIX ':math_h_c99';
 use POSIX ':nan_payload';

--- a/ext/POSIX/t/sigaction.t
+++ b/ext/POSIX/t/sigaction.t
@@ -13,7 +13,7 @@ BEGIN{
 
 use Test::More tests => 36;
 
-use strict;
+
 our ( $bad, $bad7, $ok10, $bad18, $ok );
 
 $^W=1;

--- a/ext/POSIX/t/sigset.t
+++ b/ext/POSIX/t/sigset.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/POSIX/t/sysconf.t
+++ b/ext/POSIX/t/sysconf.t
@@ -6,7 +6,7 @@ BEGIN {
     plan skip_all => "POSIX is unavailable" if $Config{'extensions'} !~ m!\bPOSIX\b!;
 }
 
-use strict;
+
 use File::Spec;
 use POSIX;
 

--- a/ext/POSIX/t/termios.t
+++ b/ext/POSIX/t/termios.t
@@ -1,6 +1,6 @@
 #!perl -Tw
 
-use strict;
+
 use Config;
 use Test::More;
 

--- a/ext/POSIX/t/time.t
+++ b/ext/POSIX/t/time.t
@@ -5,7 +5,7 @@ BEGIN {
     require 'loc_tools.pl';
 }
 
-use strict;
+
 
 use Config;
 use POSIX;

--- a/ext/POSIX/t/unimplemented.t
+++ b/ext/POSIX/t/unimplemented.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/POSIX/t/usage.t
+++ b/ext/POSIX/t/usage.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/POSIX/t/waitpid.t
+++ b/ext/POSIX/t/waitpid.t
@@ -17,7 +17,7 @@ BEGIN {
 }
 
 use warnings;
-use strict;
+
 
 $| = 1;
 

--- a/ext/POSIX/t/wrappers.t
+++ b/ext/POSIX/t/wrappers.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/PerlIO-encoding/encoding.pm
+++ b/ext/PerlIO-encoding/encoding.pm
@@ -1,6 +1,6 @@
 package PerlIO::encoding;
 
-use strict;
+
 our $VERSION = '0.28';
 our $DEBUG = 0;
 $DEBUG and warn __PACKAGE__, " called by ", join(", ", caller), "\n";

--- a/ext/PerlIO-encoding/t/threads.t
+++ b/ext/PerlIO-encoding/t/threads.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 BEGIN {

--- a/ext/PerlIO-mmap/mmap.pm
+++ b/ext/PerlIO-mmap/mmap.pm
@@ -1,5 +1,5 @@
 package PerlIO::mmap;
-use strict;
+
 use warnings;
 our $VERSION = '0.016';
 

--- a/ext/PerlIO-scalar/t/scalar_ungetc.t
+++ b/ext/PerlIO-scalar/t/scalar_ungetc.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 use IO::Handle; # ungetc()
 
 use Test::More tests => 20;

--- a/ext/PerlIO-via/t/thread.t
+++ b/ext/PerlIO-via/t/thread.t
@@ -15,7 +15,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use warnings;
 use threads;
 

--- a/ext/PerlIO-via/t/via.t
+++ b/ext/PerlIO-via/t/via.t
@@ -12,7 +12,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 use warnings;
 
 my $tmp = "via$$";

--- a/ext/Pod-Functions/Functions_pm.PL
+++ b/ext/Pod-Functions/Functions_pm.PL
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 use Pod::Simple::SimpleTree;
 
 my ($tap, $test, %Missing);
@@ -152,7 +152,7 @@ foreach ($real, $temp) {
 open my $fh, '>', $temp or die "Can't open '$temp' for writing: $!";
 print $fh <<'EOT';
 package Pod::Functions;
-use strict;
+
 
 =head1 NAME
 

--- a/ext/Pod-Functions/Makefile.PL
+++ b/ext/Pod-Functions/Makefile.PL
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use ExtUtils::MakeMaker;
 use File::Spec::Functions;
 

--- a/ext/Pod-Functions/t/Functions.t
+++ b/ext/Pod-Functions/t/Functions.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 
 use File::Basename;
 use File::Spec;

--- a/ext/Pod-Html/lib/Pod/Html.pm
+++ b/ext/Pod-Html/lib/Pod/Html.pm
@@ -1,5 +1,5 @@
 package Pod::Html;
-use strict;
+
 require Exporter;
 
 our $VERSION = 1.25;
@@ -728,7 +728,7 @@ sub _unixify {
 }
 
 package Pod::Simple::XHTML::LocalPodLinks;
-use strict;
+
 use warnings;
 use parent 'Pod::Simple::XHTML';
 

--- a/ext/Pod-Html/t/anchorify.t
+++ b/ext/Pod-Html/t/anchorify.t
@@ -1,5 +1,5 @@
 # -*- perl -*-
-use strict;
+
 use Pod::Html qw( anchorify );
 use Test::More tests => 1;
 

--- a/ext/Pod-Html/t/cache.t
+++ b/ext/Pod-Html/t/cache.t
@@ -7,7 +7,7 @@ BEGIN {
 # test the directory cache
 # XXX test --flush and %Pages being loaded/used for cross references
 
-use strict;
+
 use Cwd;
 use Pod::Html;
 use Data::Dumper;

--- a/ext/Pod-Html/t/crossref.t
+++ b/ext/Pod-Html/t/crossref.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions;
 use Test::More tests => 1;

--- a/ext/Pod-Html/t/crossref2.t
+++ b/ext/Pod-Html/t/crossref2.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use Test::More tests => 1;
 

--- a/ext/Pod-Html/t/crossref3.t
+++ b/ext/Pod-Html/t/crossref3.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use Test::More tests => 1;
 

--- a/ext/Pod-Html/t/feature.t
+++ b/ext/Pod-Html/t/feature.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions;
 use Test::More tests => 1;

--- a/ext/Pod-Html/t/feature2.t
+++ b/ext/Pod-Html/t/feature2.t
@@ -5,7 +5,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Cwd;
 use Test::More tests => 2;
 

--- a/ext/Pod-Html/t/htmldir1.t
+++ b/ext/Pod-Html/t/htmldir1.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions;
 use Test::More tests => 2;

--- a/ext/Pod-Html/t/htmldir2.t
+++ b/ext/Pod-Html/t/htmldir2.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Cwd;
 use Test::More tests => 3;
 

--- a/ext/Pod-Html/t/htmldir3.t
+++ b/ext/Pod-Html/t/htmldir3.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions;
 use Test::More tests => 2;

--- a/ext/Pod-Html/t/htmldir4.t
+++ b/ext/Pod-Html/t/htmldir4.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions ':ALL';
 use Test::More tests => 2;

--- a/ext/Pod-Html/t/htmldir5.t
+++ b/ext/Pod-Html/t/htmldir5.t
@@ -8,7 +8,7 @@ END {
     rem_test_dir();
 }
 
-use strict;
+
 use Cwd;
 use File::Spec::Functions;
 use Test::More tests => 1;

--- a/ext/Pod-Html/t/htmlescp.t
+++ b/ext/Pod-Html/t/htmlescp.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Test::More tests => 1;
 
 convert_n_test("htmlescp", "html escape");

--- a/ext/Pod-Html/t/htmllink.t
+++ b/ext/Pod-Html/t/htmllink.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Test::More tests => 1;
 
 convert_n_test("htmllink", "html links");

--- a/ext/Pod-Html/t/htmlview.t
+++ b/ext/Pod-Html/t/htmlview.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Test::More tests => 1;
 
 convert_n_test("htmlview", "html rendering", "--quiet");

--- a/ext/Pod-Html/t/poderr.t
+++ b/ext/Pod-Html/t/poderr.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Test::More tests => 1;
 
 convert_n_test("poderr", "pod error section");

--- a/ext/Pod-Html/t/podnoerr.t
+++ b/ext/Pod-Html/t/podnoerr.t
@@ -4,7 +4,7 @@ BEGIN {
     require "./t/pod2html-lib.pl";
 }
 
-use strict;
+
 use Test::More tests => 1;
 
 convert_n_test("podnoerr", "pod error section",

--- a/ext/SDBM_File/SDBM_File.pm
+++ b/ext/SDBM_File/SDBM_File.pm
@@ -1,6 +1,6 @@
 package SDBM_File;
 
-use strict;
+
 use warnings;
 
 require Tie::Hash;

--- a/ext/SDBM_File/t/constants.t
+++ b/ext/SDBM_File/t/constants.t
@@ -1,5 +1,5 @@
 #!./perl
-use strict;
+
 use Test::More tests => 4;
 
 use SDBM_File;

--- a/ext/SDBM_File/t/corrupt.t
+++ b/ext/SDBM_File/t/corrupt.t
@@ -1,5 +1,5 @@
 #!./perl
-use strict;
+
 use Test::More;
 use MIME::Base64;
 use File::Temp 'tempfile';

--- a/ext/SDBM_File/t/prep.t
+++ b/ext/SDBM_File/t/prep.t
@@ -1,5 +1,5 @@
 #!./perl
-use strict;
+
 use Test::More tests => 4;
 
 use SDBM_File;

--- a/ext/Sys-Hostname/Hostname.pm
+++ b/ext/Sys-Hostname/Hostname.pm
@@ -1,6 +1,6 @@
 package Sys::Hostname;
 
-use strict;
+
 
 use Carp;
 

--- a/ext/Tie-Hash-NamedCapture/NamedCapture.pm
+++ b/ext/Tie-Hash-NamedCapture/NamedCapture.pm
@@ -1,4 +1,4 @@
-use strict;
+
 package Tie::Hash::NamedCapture;
 
 our $VERSION = "0.13";

--- a/ext/Tie-Hash-NamedCapture/t/tiehash.t
+++ b/ext/Tie-Hash-NamedCapture/t/tiehash.t
@@ -1,5 +1,5 @@
 #!./perl -w
-use strict;
+
 
 use Test::More;
 

--- a/ext/Tie-Memoize/lib/Tie/Memoize.pm
+++ b/ext/Tie-Memoize/lib/Tie/Memoize.pm
@@ -1,4 +1,4 @@
-use strict;
+
 package Tie::Memoize;
 use Tie::Hash;
 our @ISA = 'Tie::ExtraHash';

--- a/ext/Tie-Memoize/t/Tie-Memoize.t
+++ b/ext/Tie-Memoize/t/Tie-Memoize.t
@@ -1,6 +1,6 @@
 #!./perl -w
 
-use strict;
+
 use Tie::Memoize;
 use Test::More tests => 27;
 use File::Spec;

--- a/ext/VMS-DCLsym/DCLsym.pm
+++ b/ext/VMS-DCLsym/DCLsym.pm
@@ -2,7 +2,7 @@ package VMS::DCLsym;
 
 use Carp;
 use DynaLoader;
-use strict;
+
 
 # Package globals
 our @ISA = ( 'DynaLoader' );

--- a/ext/XS-APItest/APItest.pm
+++ b/ext/XS-APItest/APItest.pm
@@ -1,7 +1,7 @@
 package XS::APItest;
 
 { use 5.011001; } # 5.11 is a long long time ago... What gives with this?
-use strict;
+
 use warnings;
 use Carp;
 

--- a/ext/XS-APItest/t/addissub.t
+++ b/ext/XS-APItest/t/addissub.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 9;
 use XS::APItest ();

--- a/ext/XS-APItest/t/arrayexpr.t
+++ b/ext/XS-APItest/t/arrayexpr.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 2*10;
 

--- a/ext/XS-APItest/t/autoload.t
+++ b/ext/XS-APItest/t/autoload.t
@@ -4,7 +4,7 @@
 # out the sub name, but also that that interface does not interfere with
 # prototypes, the way it did before 5.15.4.
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 26;

--- a/ext/XS-APItest/t/blockasexpr.t
+++ b/ext/XS-APItest/t/blockasexpr.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 16;
 

--- a/ext/XS-APItest/t/blockhooks-csc.t
+++ b/ext/XS-APItest/t/blockhooks-csc.t
@@ -2,7 +2,7 @@
 
 # Tests for @{^COMPILE_SCOPE_CONTAINER}
 
-use strict;
+
 use warnings;
 use Test::More tests => 12;
 use XS::APItest;

--- a/ext/XS-APItest/t/blockhooks.t
+++ b/ext/XS-APItest/t/blockhooks.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use warnings;
-use strict;
+
 use Test::More tests => 17;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/bootstrap.t
+++ b/ext/XS-APItest/t/bootstrap.t
@@ -6,7 +6,7 @@
 # APItest.so, the .bs should be automatically executed, which should
 # set $::bs_file_got_executed.
 
-use strict;
+
 
 use Test::More;
 use XS::APItest;

--- a/ext/XS-APItest/t/call.t
+++ b/ext/XS-APItest/t/call.t
@@ -4,7 +4,7 @@
 # DAPM Aug 2004
 
 use warnings;
-use strict;
+
 
 # Test::More doesn't have fresh_perl_is() yet
 # use Test::More tests => 342;

--- a/ext/XS-APItest/t/call_checker.t
+++ b/ext/XS-APItest/t/call_checker.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 78;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/caller.t
+++ b/ext/XS-APItest/t/caller.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use warnings;
-use strict;
+
 
 use Test::More;
 use XS::APItest;

--- a/ext/XS-APItest/t/callregexec.t
+++ b/ext/XS-APItest/t/callregexec.t
@@ -5,7 +5,7 @@
 # full tests haven't been added yet)
 
 use warnings;
-use strict;
+
 
 use XS::APItest;
 *callregexec = *XS::APItest::callregexec;

--- a/ext/XS-APItest/t/cleanup.t
+++ b/ext/XS-APItest/t/cleanup.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 3;
 

--- a/ext/XS-APItest/t/clone-with-stack.t
+++ b/ext/XS-APItest/t/clone-with-stack.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 require "../../t/test.pl";

--- a/ext/XS-APItest/t/cophh.t
+++ b/ext/XS-APItest/t/cophh.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 2;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/coplabel.t
+++ b/ext/XS-APItest/t/coplabel.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/copyhints.t
+++ b/ext/XS-APItest/t/copyhints.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/customop.t
+++ b/ext/XS-APItest/t/customop.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use warnings;
-use strict;
+
 
 use Test::More tests => 25;
 use XS::APItest;

--- a/ext/XS-APItest/t/eval-filter.t
+++ b/ext/XS-APItest/t/eval-filter.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 
 use Test::More tests => 5;
 use XS::APItest;

--- a/ext/XS-APItest/t/fetch_pad_names.t
+++ b/ext/XS-APItest/t/fetch_pad_names.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 use Encode ();
 

--- a/ext/XS-APItest/t/gotosub.t
+++ b/ext/XS-APItest/t/gotosub.t
@@ -2,7 +2,7 @@
 
 # Test that goto &xsub provides the right lexical environment.
 
-use strict;
+
 
 use Test::More tests => 1;
 use XS::APItest;

--- a/ext/XS-APItest/t/grok.t
+++ b/ext/XS-APItest/t/grok.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 
 use Test::More;
 use Config;

--- a/ext/XS-APItest/t/gv_autoload4.t
+++ b/ext/XS-APItest/t/gv_autoload4.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 31;

--- a/ext/XS-APItest/t/gv_const_sv.t
+++ b/ext/XS-APItest/t/gv_const_sv.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 use Test::More tests => 6;
 

--- a/ext/XS-APItest/t/gv_fetchmeth.t
+++ b/ext/XS-APItest/t/gv_fetchmeth.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 44;

--- a/ext/XS-APItest/t/gv_fetchmeth_autoload.t
+++ b/ext/XS-APItest/t/gv_fetchmeth_autoload.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 53;

--- a/ext/XS-APItest/t/gv_fetchmethod_flags.t
+++ b/ext/XS-APItest/t/gv_fetchmethod_flags.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 24;

--- a/ext/XS-APItest/t/gv_init.t
+++ b/ext/XS-APItest/t/gv_init.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 use Test::More tests => 12;
 

--- a/ext/XS-APItest/t/handy00.t
+++ b/ext/XS-APItest/t/handy00.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy01.t
+++ b/ext/XS-APItest/t/handy01.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy02.t
+++ b/ext/XS-APItest/t/handy02.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy03.t
+++ b/ext/XS-APItest/t/handy03.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy04.t
+++ b/ext/XS-APItest/t/handy04.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy05.t
+++ b/ext/XS-APItest/t/handy05.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy06.t
+++ b/ext/XS-APItest/t/handy06.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy07.t
+++ b/ext/XS-APItest/t/handy07.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy08.t
+++ b/ext/XS-APItest/t/handy08.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy09.t
+++ b/ext/XS-APItest/t/handy09.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/handy_base.pl
+++ b/ext/XS-APItest/t/handy_base.pl
@@ -5,7 +5,7 @@ BEGIN {
                               # find_utf8_ctype_locale()
 }
 
-use strict;
+
 use Test::More;
 use Config;
 

--- a/ext/XS-APItest/t/hash.t
+++ b/ext/XS-APItest/t/hash.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use utf8;
 use Tie::Hash;
 use Test::More;

--- a/ext/XS-APItest/t/hv_macro.t
+++ b/ext/XS-APItest/t/hv_macro.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use warnings;
 use Test::More;
 use Devel::Peek;

--- a/ext/XS-APItest/t/join_with_space.t
+++ b/ext/XS-APItest/t/join_with_space.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 1;

--- a/ext/XS-APItest/t/keyword_multiline.t
+++ b/ext/XS-APItest/t/keyword_multiline.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 4;
 

--- a/ext/XS-APItest/t/keyword_plugin.t
+++ b/ext/XS-APItest/t/keyword_plugin.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 13;
 

--- a/ext/XS-APItest/t/keyword_plugin_threads.t
+++ b/ext/XS-APItest/t/keyword_plugin_threads.t
@@ -1,5 +1,5 @@
 #!perl
-use strict;
+
 use warnings;
 
 require '../../t/test.pl';
@@ -12,7 +12,7 @@ if (!$Config{useithreads}) {
 plan(1);
 
 fresh_perl_is( <<'----', <<'====', {}, "loading XS::APItest in threads works");
-use strict;
+
 use warnings;
 
 use threads;

--- a/ext/XS-APItest/t/labelconst.t
+++ b/ext/XS-APItest/t/labelconst.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 32;
 

--- a/ext/XS-APItest/t/load-module.t
+++ b/ext/XS-APItest/t/load-module.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 
 # Test the load_module() core API function.
 #

--- a/ext/XS-APItest/t/loopblock.t
+++ b/ext/XS-APItest/t/loopblock.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 14;
 

--- a/ext/XS-APItest/t/looprest.t
+++ b/ext/XS-APItest/t/looprest.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 14;
 

--- a/ext/XS-APItest/t/lvalue.t
+++ b/ext/XS-APItest/t/lvalue.t
@@ -1,7 +1,7 @@
 # Miscellaneous tests for XS lvalue functions
 
 use warnings;
-use strict;
+
 
 use Test::More tests => 4;
 

--- a/ext/XS-APItest/t/magic.t
+++ b/ext/XS-APItest/t/magic.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 use Test::More;
 

--- a/ext/XS-APItest/t/magic_chain.t
+++ b/ext/XS-APItest/t/magic_chain.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/multicall.t
+++ b/ext/XS-APItest/t/multicall.t
@@ -5,7 +5,7 @@
 # for these macros.
 
 use warnings;
-use strict;
+
 
 use Test::More tests => 80;
 use XS::APItest;

--- a/ext/XS-APItest/t/my_cxt.t
+++ b/ext/XS-APItest/t/my_cxt.t
@@ -12,7 +12,7 @@ BEGIN {
 }
 
 use warnings;
-use strict;
+
 
 use Test::More tests => 16;
 

--- a/ext/XS-APItest/t/my_exit.t
+++ b/ext/XS-APItest/t/my_exit.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 require "test.pl";

--- a/ext/XS-APItest/t/newCONSTSUB.t
+++ b/ext/XS-APItest/t/newCONSTSUB.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use utf8;
 use open qw( :utf8 :std );
 use Test::More tests => 22;

--- a/ext/XS-APItest/t/newDEFSVOP.t
+++ b/ext/XS-APItest/t/newDEFSVOP.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 7;

--- a/ext/XS-APItest/t/op.t
+++ b/ext/XS-APItest/t/op.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use utf8;
 use Test::More 'no_plan';
 

--- a/ext/XS-APItest/t/op_contextualize.t
+++ b/ext/XS-APItest/t/op_contextualize.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/op_list.t
+++ b/ext/XS-APItest/t/op_list.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 2;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/overload.t
+++ b/ext/XS-APItest/t/overload.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use Test::More;
 
 BEGIN {use_ok('XS::APItest')};

--- a/ext/XS-APItest/t/pad_scalar.t
+++ b/ext/XS-APItest/t/pad_scalar.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 76;
 

--- a/ext/XS-APItest/t/peep.t
+++ b/ext/XS-APItest/t/peep.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 use Test::More tests => 6;
 

--- a/ext/XS-APItest/t/pmflag.t
+++ b/ext/XS-APItest/t/pmflag.t
@@ -1,5 +1,5 @@
 #!perl
-use strict;
+
 use Test::More 'tests' => 2;
 
 ok(!eval q{use XS::APItest 'pmflag'; 1}, "Perl_pmflag\(\) removed");

--- a/ext/XS-APItest/t/postinc.t
+++ b/ext/XS-APItest/t/postinc.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 8;
 

--- a/ext/XS-APItest/t/ptr_table.t
+++ b/ext/XS-APItest/t/ptr_table.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 
 use XS::APItest;
 use Test::More;

--- a/ext/XS-APItest/t/refs.t
+++ b/ext/XS-APItest/t/refs.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 9;

--- a/ext/XS-APItest/t/rmagical.t
+++ b/ext/XS-APItest/t/rmagical.t
@@ -8,7 +8,7 @@
 # mg_magical won't turn SvRMAGICAL on. However, if the chain is in the
 # opposite order (sv -> A -> B -> NULL), SvRMAGICAL used to be turned on.
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 3;

--- a/ext/XS-APItest/t/rv2cv_op_cv.t
+++ b/ext/XS-APItest/t/rv2cv_op_cv.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/savehints.t
+++ b/ext/XS-APItest/t/savehints.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 use Test::More tests => 1;
 
 use XS::APItest;

--- a/ext/XS-APItest/t/scopelessblock.t
+++ b/ext/XS-APItest/t/scopelessblock.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 18;
 

--- a/ext/XS-APItest/t/sort.t
+++ b/ext/XS-APItest/t/sort.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use warnings;
 use Test::More tests => 2;
 

--- a/ext/XS-APItest/t/stmtasexpr.t
+++ b/ext/XS-APItest/t/stmtasexpr.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 10;
 

--- a/ext/XS-APItest/t/stmtsasexpr.t
+++ b/ext/XS-APItest/t/stmtsasexpr.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 10;
 

--- a/ext/XS-APItest/t/stuff_modify_bug.t
+++ b/ext/XS-APItest/t/stuff_modify_bug.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 1;
 

--- a/ext/XS-APItest/t/stuff_svcur_bug.t
+++ b/ext/XS-APItest/t/stuff_svcur_bug.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 1;
 ok 1;

--- a/ext/XS-APItest/t/subsignature.t
+++ b/ext/XS-APItest/t/subsignature.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More;
 

--- a/ext/XS-APItest/t/svcatpvf.t
+++ b/ext/XS-APItest/t/svcatpvf.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 
 use Test::More tests => 4;

--- a/ext/XS-APItest/t/sviscow.t
+++ b/ext/XS-APItest/t/sviscow.t
@@ -1,4 +1,4 @@
-use strict;
+
 
 use Test::More tests => 1;
 

--- a/ext/XS-APItest/t/svpeek.t
+++ b/ext/XS-APItest/t/svpeek.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 
 use Test::More tests => 52;

--- a/ext/XS-APItest/t/svsetsv.t
+++ b/ext/XS-APItest/t/svsetsv.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 
 use Test::More tests => 7;

--- a/ext/XS-APItest/t/swaplabel.t
+++ b/ext/XS-APItest/t/swaplabel.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 56;
 

--- a/ext/XS-APItest/t/swaptwostmts.t
+++ b/ext/XS-APItest/t/swaptwostmts.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 32;
 

--- a/ext/XS-APItest/t/synthetic_scope.t
+++ b/ext/XS-APItest/t/synthetic_scope.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 18;

--- a/ext/XS-APItest/t/temp_lv_sub.t
+++ b/ext/XS-APItest/t/temp_lv_sub.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use utf8;
 use Test::More tests => 5;
 

--- a/ext/XS-APItest/t/underscore_length.t
+++ b/ext/XS-APItest/t/underscore_length.t
@@ -1,5 +1,5 @@
 use warnings;
-use strict;
+
 
 use Test::More tests => 2;
 

--- a/ext/XS-APItest/t/utf16_to_utf8.t
+++ b/ext/XS-APItest/t/utf16_to_utf8.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use Test::More;
 use Encode;
 

--- a/ext/XS-APItest/t/utf8.t
+++ b/ext/XS-APItest/t/utf8.t
@@ -1,6 +1,6 @@
 #!perl -w
 
-use strict;
+
 use Test::More;
 
 # This file tests various functions and macros in the API related to UTF-8.

--- a/ext/XS-APItest/t/utf8_to_bytes.t
+++ b/ext/XS-APItest/t/utf8_to_bytes.t
@@ -7,7 +7,7 @@
 # perturbs it to be malformed in various ways, and tests that this gets
 # appropriately detected.
 
-use strict;
+
 use Test::More;
 
 BEGIN {

--- a/ext/XS-APItest/t/utf8_warn00.t
+++ b/ext/XS-APItest/t/utf8_warn00.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn01.t
+++ b/ext/XS-APItest/t/utf8_warn01.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn02.t
+++ b/ext/XS-APItest/t/utf8_warn02.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn03.t
+++ b/ext/XS-APItest/t/utf8_warn03.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn04.t
+++ b/ext/XS-APItest/t/utf8_warn04.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn05.t
+++ b/ext/XS-APItest/t/utf8_warn05.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn06.t
+++ b/ext/XS-APItest/t/utf8_warn06.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn07.t
+++ b/ext/XS-APItest/t/utf8_warn07.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn08.t
+++ b/ext/XS-APItest/t/utf8_warn08.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn09.t
+++ b/ext/XS-APItest/t/utf8_warn09.t
@@ -1,4 +1,4 @@
-use strict;
+
 use warnings;
 no warnings 'once';
 

--- a/ext/XS-APItest/t/utf8_warn_base.pl
+++ b/ext/XS-APItest/t/utf8_warn_base.pl
@@ -7,7 +7,7 @@
 # perturbs it to be malformed in various ways, and tests that this gets
 # appropriately detected.
 
-use strict;
+
 use Test::More;
 
 BEGIN {

--- a/ext/XS-APItest/t/weaken.t
+++ b/ext/XS-APItest/t/weaken.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 7;

--- a/ext/XS-APItest/t/whichsig.t
+++ b/ext/XS-APItest/t/whichsig.t
@@ -1,6 +1,6 @@
 #!perl
 
-use strict;
+
 use warnings;
 
 use Test::More tests => 9;

--- a/ext/XS-APItest/t/win32.t
+++ b/ext/XS-APItest/t/win32.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 use Test::More;
 use XS::APItest;
 use Config;

--- a/ext/XS-APItest/t/xs_special_subs.t
+++ b/ext/XS-APItest/t/xs_special_subs.t
@@ -5,7 +5,7 @@ BEGIN {
     $XS::APItest::WARNINGS_ON_BOOTSTRAP = 1;
 }
 
-use strict;
+
 use warnings;
 use Test::More tests => 100;
 

--- a/ext/XS-APItest/t/xs_special_subs_require.t
+++ b/ext/XS-APItest/t/xs_special_subs_require.t
@@ -5,7 +5,7 @@ BEGIN {
     $XS::APItest::WARNINGS_ON_BOOTSTRAP = 1;
 }
 
-use strict;
+
 use warnings;
 use Test::More tests => 103;
 

--- a/ext/XS-APItest/t/xsub_h.t
+++ b/ext/XS-APItest/t/xsub_h.t
@@ -1,5 +1,5 @@
 #!perl -w
-use strict;
+
 
 use Test::More;
 

--- a/ext/XS-Typemap/t/Typemap.t
+++ b/ext/XS-Typemap/t/Typemap.t
@@ -8,7 +8,7 @@ BEGIN {
 
 use Test::More tests => 156;
 
-use strict;
+
 #catch WARN_INTERNAL type errors, and anything else unexpected
 use warnings FATAL => 'all';
 use XS::Typemap;

--- a/ext/mro/mro.pm
+++ b/ext/mro/mro.pm
@@ -7,7 +7,7 @@
 #      License or the Artistic License, as specified in the README file.
 #
 package mro;
-use strict;
+
 use warnings;
 
 # mro.pm versions < 1.00 reserved for MRO::Compat

--- a/ext/re/re.pm
+++ b/ext/re/re.pm
@@ -1,7 +1,7 @@
 package re;
 
 # pragma for controlling the regexp engine
-use strict;
+
 use warnings;
 
 our $VERSION     = "0.40";

--- a/ext/re/t/lexical_debug.t
+++ b/ext/re/t/lexical_debug.t
@@ -8,7 +8,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 
 # must use a BEGIN or the prototypes wont be respected meaning 
     # tests could pass that shouldn't

--- a/ext/re/t/re.t
+++ b/ext/re/t/re.t
@@ -8,7 +8,7 @@ BEGIN {
 	}
 }
 
-use strict;
+
 
 my $re_taint_bit = 0x00100000;
 my $re_eval_bit = 0x00200000;

--- a/ext/re/t/re_funcs.t
+++ b/ext/re/t/re_funcs.t
@@ -8,7 +8,7 @@ BEGIN {
 	}
 }
 
-use strict;
+
 use warnings;
 
 use Test::More; # test count at bottom of file

--- a/ext/re/t/re_funcs_u.t
+++ b/ext/re/t/re_funcs_u.t
@@ -10,7 +10,7 @@ BEGIN {
     require 'loc_tools.pl'; # To see if platform has locales
 }
 
-use strict;
+
 use warnings;
 
 use re qw(is_regexp regexp_pattern

--- a/ext/re/t/reflags.t
+++ b/ext/re/t/reflags.t
@@ -9,7 +9,7 @@ BEGIN {
         require 'loc_tools.pl';
 }
 
-use strict;
+
 
 use Test::More tests => 74;
 

--- a/ext/re/t/regop.t
+++ b/ext/re/t/regop.t
@@ -8,7 +8,7 @@ BEGIN {
     }
 }
 
-use strict;
+
 BEGIN { require "../../t/test.pl"; }
 our $NUM_SECTS;
 chomp(my @strs= grep { !/^\s*\#/ } <DATA>);

--- a/ext/re/t/strict.t
+++ b/ext/re/t/strict.t
@@ -10,7 +10,7 @@ BEGIN {
         }
 }
 
-use strict;
+
 
 use Test::More tests => 10;
 BEGIN { require_ok( 're' ); }


### PR DESCRIPTION
Files under ext/ are not dual-life and are completely under the control
of P5P (or whatever governance succeeds P5P).  Hence, for the purpose of
our research, we can remove remaining instances.

For: https://github.com/atoomic/perl/issues/104