### PR TITLE
Issue 242 

### DIFF
--- a/t/op/threads.t
+++ b/t/op/threads.t
@@ -12,7 +12,6 @@ BEGIN {
      plan(30);
 }
 
-use strict;
 use warnings;
 use threads;
 
@@ -230,7 +229,6 @@ EOI
 # This will fail in "interesting" ways if stashes in clone_params is not
 # initialised correctly.
 fresh_perl_like(<<'EOI', qr/\AThread 1 terminated abnormally: Not a CODE reference/, { }, 'RT #73046');
-    use strict;
     use threads;
 
     sub foo::bar;
@@ -290,7 +288,6 @@ EOI
 
 # Test from Jerry Hedden, reduced by him from Object::InsideOut's tests.
 fresh_perl_is(<<'EOI', 'ok', { }, '0 refcnt during CLONE');
-use strict;
 use warnings;
 
 use threads;

--- a/t/op/tiehandle.t
+++ b/t/op/tiehandle.t
@@ -196,7 +196,7 @@ is($r, 1);
     @expect = (PRINT => $obj, "stuff", "and", "things");
     ::ok( print $fh @expect[2..4] );
     ::is( $ors, 'something' );
-    
+
     ::ok( say $fh @expect[2..4] );
     ::is( $ors, "\n",        'say sets $\ to \n in PRINT' );
     ::is( $\,   "something", "  and it's localized" );
@@ -210,7 +210,6 @@ is($r, 1);
 {
     # Test for change #11536
     package Foo;
-    use strict;
     sub TIEHANDLE { bless {} }
     my $cnt = 'a';
     sub READ {

--- a/t/op/write.t
+++ b/t/op/write.t
@@ -8,7 +8,8 @@ BEGIN {
 
 $| = 0; # test.pl now sets it on, which causes problems here.
 
-use strict;	# Amazed that this hackery can be made strict ...
+# use strict;	
+# Amazed that this hackery can be made strict ...
 use Tie::Scalar;
 
 # read in a file
@@ -1645,7 +1646,6 @@ SKIP: {
 fresh_perl_like(<<'EOP', qr/^Format STDOUT redefined at/, {stderr => 1}, '#64562 - Segmentation fault with redefined formats and warnings');
 #!./perl
 
-use strict;
 use warnings; # crashes!
 
 format =

--- a/t/porting/test_bootstrap.t
+++ b/t/porting/test_bootstrap.t
@@ -20,7 +20,6 @@ my %exceptions = (
     hints => "require './test.pl'",
     parser => 'use DieDieDie',
     parser_run => "require './test.pl'",
-    proto => 'use strict',
  );
 
 while (my $file = <$fh>) {


### PR DESCRIPTION
use strict within a codeblock (appears to be a hash passed to external test runners). t/porting/test_boostrap.t