### PR TITLE
Jkeenan/math complex t complex 20201010

### DIFF
--- a/cpan/Math-Complex/t/Complex.t
+++ b/cpan/Math-Complex/t/Complex.t
@@ -16,7 +16,7 @@ my ($args, $op, $target, $test, $test_set, $try, $val, $zvalue, @set, @val);
 $test = 0;
 $| = 1;
 my @script = (
-    'my ($res, $s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8,$s9,$s10,$z0,$z1,$z2,$bad);' .
+    'my ($res, $s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8,$s9,$s10,$z0,$z1,$z2,$bad,$z);' .
 	"\n\n"
 );
 my $eps = 1e-13;
@@ -74,7 +74,7 @@ sub test_mutators {
     $test++;
 push(@script, <<'EOT');
 {
-    my $z = cplx(  1,  1);
+    $z = cplx(  1,  1);
     $z->Re(2);
     $z->Im(3);
     print "# $test Re(z) = ",$z->Re(), " Im(z) = ", $z->Im(), " z = $z\n";
@@ -85,7 +85,7 @@ EOT
     $test++;
 push(@script, <<'EOT');
 {
-    my $z = cplx(  1,  1);
+    $z = cplx(  1,  1);
     $z->abs(3 * sqrt(2));
     print "# $test Re(z) = ",$z->Re(), " Im(z) = ", $z->Im(), " z = $z\n";
     print 'not ' unless (abs($z) - 3 * sqrt(2)) < $eps and
@@ -98,7 +98,7 @@ EOT
     $test++;
 push(@script, <<'EOT');
 {
-    my $z = cplx(  1,  1);
+    $z = cplx(  1,  1);
     $z->arg(-3 / 4 * pi);
     print "# $test Re(z) = ",$z->Re(), " Im(z) = ", $z->Im(), " z = $z\n";
     print 'not ' unless (arg($z) + 3 / 4 * pi) < $eps and
@@ -542,7 +542,7 @@ sub set {
 	for ($i = 0; $i < @set; $i++) {
 		push(@{$valref}, $set[$i]);
 		my $val = value($set[$i]);
-		push @script, "\$s$i = $val;\n";
+		push @script, "no warnings 'shadow'; \$s$i = $val;\n";
 		push @{$setref}, "\$s$i";
 	}
 }

--- a/cpan/Math-Complex/t/Complex.t
+++ b/cpan/Math-Complex/t/Complex.t
@@ -16,7 +16,7 @@ my ($args, $op, $target, $test, $test_set, $try, $val, $zvalue, @set, @val);
 $test = 0;
 $| = 1;
 my @script = (
-    'my ($res, $s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8,$s9,$s10,$z0,$z1,$z2);' .
+    'my ($res, $s0,$s1,$s2,$s3,$s4,$s5,$s6,$s7,$s8,$s9,$s10,$z0,$z1,$z2,$bad);' .
 	"\n\n"
 );
 my $eps = 1e-13;
@@ -136,7 +136,7 @@ sub test_dbz {
 	$test++;
 	push(@script, <<EOT);
 	eval '$op';
-	(my \$bad) = (\$@ =~ /(.+)/);
+	(\$bad) = (\$@ =~ /(.+)/);
 	print "# $test op = $op divbyzero? \$bad...\n";
 	print 'not ' unless (\$@ =~ /Division by zero/);
 EOT


### PR DESCRIPTION
This p.r. eliminates the following warnings from `cpan/Math-Complex/t/Complex.t`:
```
cpan/Math-Complex/t/Complex .................................... "my" variable $bad masks earlier declaration in same scope at (eval 4) line 3381, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3387, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3393, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3399, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3405, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3411, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3417, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3423, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3429, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3435, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3441, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3447, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3453, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3459, <DATA> line 545.
"my" variable $bad masks earlier declaration in same scope at (eval 4) line 3465, <DATA> line 545.
"my" variable $z masks earlier declaration in same scope at (eval 4) line 3616, <DATA> line 545.
"my" variable $z masks earlier declaration in same scope at (eval 4) line 3622, <DATA> line 545.
"my" variable $z masks earlier declaration in same scope at (eval 4) line 3628, <DATA> line 545.
"my" variable $z masks earlier declaration in same scope at (eval 4) line 3634, <DATA> line 545.
"my" variable $z masks earlier declaration in same scope at (eval 4) line 3640, <DATA> line 545.
ok
```
However, I suspect that using `no warnings 'shadow';` for the `$z` warnings may be sub-optimal.  Please review.

Thank you very much.
Jim Keenan