### PR TITLE
remove stricture from t/op/print.t

### DIFF
--- a/t/op/print.t
+++ b/t/op/print.t
@@ -16,7 +16,6 @@ SKIP: {
     skip_if_miniperl('no dynamic loading of PerlIO::scalar in miniperl');
     skip("overlong UTF-8 test is ASCII-centric") if $::IS_EBCDIC;    # Varies depending on code page
 fresh_perl_is(<<'EOF', "\xC1\xAF\xC1\xAF\xC1\xB0\xC1\xB3", {}, "print doesn't launder utf8 overlongs");
-use strict;
 use warnings;
 
 no warnings 'utf8';


### PR DESCRIPTION
Issue #218 study for strict on by default. t/op/print.t remove stricture