### PR TITLE
Jkeenan/ext warnings 1

### DIFF
--- a/ext/Devel-Peek/t/Peek.t
+++ b/ext/Devel-Peek/t/Peek.t
@@ -19,7 +19,9 @@ use Devel::Peek;
 
 our $DEBUG = 0;
 our ( @array, %hash );
-open(SAVERR, ">&STDERR") or die "Can't dup STDERR: $!";
+{
+    no warnings 'once';
+    open(SAVERR, ">&STDERR") or die "Can't dup STDERR: $!";
 
 # If I reference any lexicals in this, I get the entire outer subroutine (or
 # MAIN) dumped too, which isn't really what I want, as it's a lot of faff to
@@ -30,6 +32,7 @@ $::type
 Good    @>>>>>
 $::mmmm
 .
+}
 
 use constant thr => $Config{useithreads};
 
@@ -847,7 +850,7 @@ do_test('ENAMEs on a stash with no NAME',
 ');
 
 my %small = ("Perl", "Rules", "Beer", "Foamy");
-my $b = %small;
+$b = %small;
 do_test('small hash',
         \%small,
 'SV = $RV\\($ADDR\\) at $ADDR
@@ -1351,6 +1354,7 @@ like(
     my $coderef = eval <<"EOP";
     use feature 'lexical_subs';
     no warnings 'experimental::lexical_subs';
+    no warnings 'illegalproto';
     my sub bar (\$\x{30cd}) {1}; \\&bar
 EOP
     like(
@@ -1512,7 +1516,7 @@ EODUMP
                  prog => 'package t; use Devel::Peek q-DumpProg-; DumpProg();',
                  stderr=>1;
     $out =~ s/ *SEQ = .*\n//;
-    $out =~ s/0x[0-9a-f]{2,}\]/${1}0xNNN]/g;
+    { no warnings 'uninitialized'; $out =~ s/0x[0-9a-f]{2,}\]/${1}0xNNN]/g; }
     $out =~ s/\(0x[0-9a-f]{3,}\)/(0xNNN)/g;
     is $out, $e, "DumpProg() has no 'Attempt to free X prematurely' warning";
 }

--- a/ext/Fcntl/t/syslfs.t
+++ b/ext/Fcntl/t/syslfs.t
@@ -24,9 +24,11 @@ our @s;
 
 my $explained;
 
-sub explain {
-    unless ($explained++) {
-	print <<EOM;
+{
+    no warnings 'redefine';  # We're replacing Test::More::explain()
+    sub explain {
+        unless ($explained++) {
+            print <<EOM;
 #
 # If the lfs (large file support: large meaning larger than two
 # gigabytes) tests are skipped or fail, it may mean either that your
@@ -42,9 +44,10 @@ sub explain {
 # It is just that the test failed now.
 #
 EOM
-    }
-    if (@_) {
-	plan(skip_all => "@_");
+        }
+        if (@_) {
+            plan(skip_all => "@_");
+        }
     }
 }
 

--- a/ext/File-Glob/t/basic.t
+++ b/ext/File-Glob/t/basic.t
@@ -112,7 +112,7 @@ SKIP: {
     TODO: {
         local $TODO = 'directory brackets look like pattern brackets to glob' if $^O eq 'VMS';
         my $home = exists $ENV{HOME} ? $ENV{HOME}
-        : eval { getpwuid($>); 1 } ? (getpwuid($>))[7]
+        : eval { no warnings 'void'; getpwuid($>); 1 } ? (getpwuid($>))[7]
         : $^O eq 'MSWin32' && exists $ENV{USERPROFILE} ? $ENV{USERPROFILE}
         : q{~};
         $tilde_check->($home);

--- a/ext/FileCache/t/04twoarg.t
+++ b/ext/FileCache/t/04twoarg.t
@@ -11,6 +11,7 @@ END { unlink('foo') }
 use Test::More tests => 1;
 
 {# Test 4: that 2 arg format works, and that we cycle on mode change
+     no warnings 'reserved';
      cacheout '>', "foo";
      print foo "foo 4\n";
      cacheout '+>', "foo";

--- a/ext/I18N-Langinfo/t/Langinfo.t
+++ b/ext/I18N-Langinfo/t/Langinfo.t
@@ -144,7 +144,10 @@ SKIP: {
         $message .= "time name" unless $found_time;
         if (! $found_monetary) {
             $message .= " nor" if $message;
-            "monetary name";
+            {
+                no warnings 'void';
+                "monetary name";
+            }
         }
         skip("Couldn't find a locale with a non-ascii $message", 2 - $found_time - $found_monetary);
     }

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -77,6 +77,7 @@ SKIP: {
     my ($reader, $writer) = ('') x 2;
     cmp_ok($fds[0], '>', $testfd, 'POSIX::pipe');
 
+    no warnings 'once';
     CORE::open($reader = \*READER, "<&=".$fds[0]);
     CORE::open($writer = \*WRITER, ">&=".$fds[1]);
     my $test = next_test();
@@ -355,7 +356,7 @@ is ($result, undef, "fgets should fail");
 like ($@, qr/^Unimplemented: POSIX::fgets\(\): Use method IO::Handle::gets\(\) instead/,
       "check its redef message");
 
-eval { use strict; POSIX->import("S_ISBLK"); my $x = S_ISBLK };
+eval { use strict; no warnings 'uninitialized'; POSIX->import("S_ISBLK"); my $x = S_ISBLK };
 unlike( $@, qr/Can't use string .* as a symbol ref/, "Can import autoloaded constants" );
 
 SKIP: {

--- a/ext/POSIX/t/sigaction.t
+++ b/ext/POSIX/t/sigaction.t
@@ -115,7 +115,7 @@ SKIP: {
     skip("SIGCONT not trappable in $^O", 1)
 	if ($^O eq 'VMS');
     $newaction=POSIX::SigAction->new(sub { ++$ok10; });
-    if (eval { SIGCONT; 1 }) {
+    if (eval { no warnings 'void'; SIGCONT; 1 }) {
 	sigaction(SIGCONT, POSIX::SigAction->new('DEFAULT'));
 	{
 	    local($^W)=0;
@@ -218,7 +218,7 @@ SKIP: {
         for my $field (sort keys %{{ %siginfo, %opt_val }}) {
             SKIP: {
                 skip("siginfo_t has no $field field", 1)
-                    unless %always{$field} or ($Config{"d_siginfo_si_$field"} || '') eq 'define';
+                    unless $always{$field} or ($Config{"d_siginfo_si_$field"} || '') eq 'define';
                 skip("no constant defined for SA_SIGINFO $field value $opt_val{$field}", 1)
                     unless defined $siginfo{$field};
                 skip("SA_SIGINFO $field value is wrong on $^O: $skip{$field}{$^O}", 1)

--- a/ext/POSIX/t/sysconf.t
+++ b/ext/POSIX/t/sysconf.t
@@ -7,6 +7,7 @@ BEGIN {
 }
 
 use strict;
+use warnings;
 use File::Spec;
 use POSIX;
 
@@ -110,12 +111,12 @@ SKIP: {
 
     -c $TTY
 	or skip("$TTY not a character file", $n);
-    open(TTY, '<', $TTY)
+    open(my $LEXTTY, '<', $TTY)
 	or skip("failed to open $TTY: $!", $n);
-    -t TTY
-	or skip("TTY ($TTY) not a terminal file", $n);
+    -t $LEXTTY
+	or skip("$LEXTTY ($TTY) not a terminal file", $n);
 
-    my $fd = fileno(TTY);
+    my $fd = fileno($LEXTTY);
 
     # testing fpathconf() on a terminal file
     for my $constant (@path_consts_terminal) {
@@ -123,7 +124,7 @@ SKIP: {
 			  "calling fpathconf($fd, $constant) ($TTY)");
     }
     
-    close($fd);
+    close($LEXTTY);
     # testing pathconf() on a terminal file
     for my $constant (@path_consts_terminal) {
 	_check_and_report(sub { pathconf($TTY, shift) }, $constant,

--- a/ext/POSIX/t/sysconf.t
+++ b/ext/POSIX/t/sysconf.t
@@ -6,8 +6,6 @@ BEGIN {
     plan skip_all => "POSIX is unavailable" if $Config{'extensions'} !~ m!\bPOSIX\b!;
 }
 
-use strict;
-use warnings;
 use File::Spec;
 use POSIX;
 

--- a/ext/PerlIO-encoding/t/fallback.t
+++ b/ext/PerlIO-encoding/t/fallback.t
@@ -42,13 +42,13 @@ close($fh);
 
 $PerlIO::encoding::fallback = Encode::HTMLCREF;
 
-ok(open(my $fh,">encoding(iso-8859-1)",$file),"opened iso-8859-1 file");
+ok(open($fh,">encoding(iso-8859-1)",$file),"opened iso-8859-1 file");
 my $str = "\x{20AC}";
 print $fh $str,"0.02\n";
 close($fh);
 
 open($fh,'<',$file) || die "File cannot be re-opened";
-my $line = <$fh>;
+$line = <$fh>;
 is($line,"&#8364;0.02\n","HTML escapes");
 close($fh);
 
@@ -61,7 +61,7 @@ close($fh);
 }
 
 ok(open($fh,"<encoding(US-ASCII)",$file),"Opened as ASCII");
-my $line = <$fh>;
+$line = <$fh>;
 printf "# %x\n",ord($line);
 is($line,"\\xA30.02\n","Escaped non-mapped char");
 close($fh);

--- a/ext/SDBM_File/t/corrupt.t
+++ b/ext/SDBM_File/t/corrupt.t
@@ -16,7 +16,7 @@ $Config{shortsize} == 2
 my ($dirfh, $dirname) = tempfile(UNLINK => 1);
 my ($pagfh, $pagname) = tempfile(UNLINK => 1);
 close $dirfh;
-close pagefh;
+{no warnings 'once'; no warnings 'reserved'; close pagefh;}
 
 # these might only fail under ASAN
 while (my $testdata = do { local $/ = "END\n"; <DATA>; }) {


### PR DESCRIPTION
This pull request **partially** satisfies the ask in [ext/: implement warnings-by-default
](https://github.com/atoomic/perl/issues/305).  It eliminates all warnings when test files under `ext/` are run with warnings on by default.

The warnings it does **not** eliminate are the subject of discussion in these 3 tickets in the Perl5 bug queue.

https://github.com/Perl/perl5/issues/18244
https://github.com/Perl/perl5/issues/18245
https://github.com/Perl/perl5/issues/18249

Please review.

Thank you very much.
Jim Keenan