### PR TITLE
dumper.t: Turning on Deparse changes output to be expected

### DIFF
--- a/dist/Data-Dumper/t/dumper.t
+++ b/dist/Data-Dumper/t/dumper.t
@@ -1100,6 +1100,7 @@ TEST q(Data::Dumper->new([[$c, $d]])->Dumpxs;), "more sortkeys sub (XS)"
   $WANT = <<'EOT';
 #$VAR1 = {
 #          foo => sub {
+#                     use warnings;
 #                     use strict;
 #                     print 'foo';
 #                 }


### PR DESCRIPTION
For:  https://github.com/atoomic/perl/issues/317