### PR TITLE
t/op/each.t: Ensure test numbers print properly

### DIFF
--- a/t/op/each.t
+++ b/t/op/each.t
@@ -122,7 +122,7 @@ SKIP: {
     is (keys(%hash), 10, "keys (%hash)");
 }
 
-my @tests = (&next_test, &next_test, &next_test);
+@main::tests = (&next_test, &next_test, &next_test);
 {
     package Obj;
     sub DESTROY { print "ok $::tests[1] # DESTROY called\n"; }


### PR DESCRIPTION
In Perl 5, test.pl's next_test() is called 3 times within this file in
order to make use of test numbers in 'print' statements.  The return
values of these 3 sub calls were stored in global variable @tests, then
subsequently accessed via code like '$::tests[0]'.

When preparing this file to run under strict-by-default, variable
'@tests' was lexically scoped with 'my'.  But subsequent code was still
calling elements of @main::tests, even though *this* array had not yet
been assigned to.  As a result, the line number was not appearing in the
test description.

        ok 15 - keys (%hash)
        ok
        ok  # DESTROY called
        ok
        ok 19 - Check length of "\x{1234}"

This patch corrects the scoping.

        ok 15 - keys (%hash)
        ok 16
        ok 17 # DESTROY called
        ok 18
        ok 19 - Check length of "\x{1234}"

Branches forked from alpha after alpha-dev-02-strict was merged in
(e.g., alpha-dev-03-warnings and branches forked therefrom) will
have to be rebased on alpha once this branch is merged thereto.