### PR TITLE
T op warnings group 1 20201211

### DIFF
--- a/ext/POSIX/t/sysconf.t
+++ b/ext/POSIX/t/sysconf.t
@@ -6,6 +6,8 @@ BEGIN {
     plan skip_all => "POSIX is unavailable" if $Config{'extensions'} !~ m!\bPOSIX\b!;
 }
 
+use strict;
+use warnings;
 use File::Spec;
 use POSIX;
 

--- a/pod/perldiag.pod
+++ b/pod/perldiag.pod
@@ -50,6 +50,11 @@ letter.
 to check the return value of your socket() call?  See
 L<perlfunc/accept>.
 
+=item accept() on unopened socket %s
+
+(W unopened) You tried to do an accept on a socket that was never opened.
+L<perlfunc/accept>.
+
 =item Aliasing via reference is experimental
 
 (S experimental::refaliasing) This warning is emitted if you use
@@ -595,6 +600,16 @@ L<perlport> for more on portability concerns.
 
 (W closed) You tried to do a bind on a closed socket.  Did you forget to
 check the return value of your socket() call?  See L<perlfunc/bind>.
+
+=item bind() on unopened socket %s
+
+(W unopened) You tried to do a bind on a socket that was never opened.
+See L<perlfunc/bind>.
+
+=item binmode() on unopened filehandle %s
+
+(W unopened) You tried binmode() on a filehandle that was never opened.
+Check your control flow and number of arguments.
 
 =item binmode() on closed filehandle %s
 
@@ -1812,6 +1827,11 @@ on I<Mastering Regular Expressions>.)
 
 (W closed) You tried to do a connect on a closed socket.  Did you forget
 to check the return value of your socket() call?  See
+L<perlfunc/connect>.
+
+=item connect() on unopened socket %s
+
+(W unopened) You tried to do a connect on a socket that was never opened.  See
 L<perlfunc/connect>.
 
 =item Constant(%s): Call to &{$^H{%s}} did not return a defined value

--- a/t/op/anonsub.t
+++ b/t/op/anonsub.t
@@ -92,6 +92,7 @@ EXPECT
 Undefined subroutine called at - line 4.
 ########
 # NAME anon constant clobbering __ANON__
+no warnings 'void';
 sub __ANON__ { "42\n" }
 print __ANON__;
 sub(){3};

--- a/t/op/args.t
+++ b/t/op/args.t
@@ -72,7 +72,7 @@ my $foo = 'foo'; local1($foo); local1($foo);
 is($foo, 'foo',
     "got 'foo' as expected rather than '\$foo': RT \#21542");
 
-sub local2 { local $_[0]; last L }
+sub local2 { no warnings 'exiting'; local $_[0]; last L }
 L: { local2 }
 pass("last to label");
 

--- a/t/op/auto.t
+++ b/t/op/auto.t
@@ -50,8 +50,11 @@ cmp_ok($x{0},          '==',10000,'helem x final');
 
 my $foo;
 cmp_ok(++($foo = '99'), 'eq','100','99 incr 100');
-cmp_ok(++($foo = "99a"), 'eq','100','99a incr 100');
-cmp_ok(++($foo = "99\0a"), 'eq','100','99\0a incr 100');
+{
+    no warnings 'numeric';
+    cmp_ok(++($foo = "99a"), 'eq','100','99a incr 100');
+    cmp_ok(++($foo = "99\0a"), 'eq','100','99\0a incr 100');
+}
 cmp_ok(++($foo = 'a0'), 'eq','a1','a0 incr a1');
 cmp_ok(++($foo = 'Az'), 'eq','Ba','Az incr Ba');
 cmp_ok(++($foo = 'zz'), 'eq','aaa','zzz incr aaa');
@@ -62,7 +65,9 @@ cmp_ok(++($foo = 'zr'), 'eq','zs','zr incr zs (EBCDIC r,s non-contiguous check)'
 # test with glob copies
 
 for(qw '$x++ ++$x $x-- --$x') {
+  no warnings 'once';
   my $x = *foo;
+  no warnings 'numeric';
   ok eval "$_; 1", "$_ does not die on a glob copy";
   is $x, /-/ ? -1 : 1, "result of $_ on a glob copy";
 }

--- a/t/op/avhv.t
+++ b/t/op/avhv.t
@@ -155,6 +155,7 @@ not_hash($@);
 
 $avhv = [{foo=>1, bar=>2}];
 eval {
+    no warnings 'misc';
     %$avhv =~ m,^\d+/\d+,;
 };
 not_hash($@);

--- a/t/op/blocks.t
+++ b/t/op/blocks.t
@@ -52,6 +52,7 @@ eval 'UNITCHECK {print ":u3"; UNITCHECK {print ":u4"}}';
 	   BEGIN {print ":b6-c"}})/x;
 {
     use re 'eval';
+    no warnings 'void';
     my $runtime = q{
     (?{UNITCHECK {print ":u5-r"};
 	       CHECK {print ":c2-r"};
@@ -122,13 +123,18 @@ fresh_perl_is(<<'SCRIPT70614', "still here",{switches => [''], stdin => '', stde
 eval "UNITCHECK { eval 0 }"; print "still here";
 SCRIPT70614
 
-# [perl #78634] Make sure block names can be used as constants.
-use constant INIT => 5;
+BEGIN {
+    # [perl #78634] Make sure block names can be used as constants.
+    # Also, suppress compile-time warning: Constant name '$name' is a Perl keyword
+    no warnings;
+    use constant INIT => 5;
+}
 ::is INIT, 5, 'constant named after a special block';
 
 # [perl #108794] context
 fresh_perl_is(<<'SCRIPT3', <<expEct,{stderr => 1 },'context');
 sub context {
+    no warnings 'uninitialized';
     print qw[void scalar list][wantarray + defined wantarray], "\n"
 }
 BEGIN     {context}

--- a/t/op/concat2.t
+++ b/t/op/concat2.t
@@ -18,7 +18,7 @@ plan 4;
 { package o; use overload '""' => sub { $_[0][0] } }
 my $x = bless[chr 256],o::;
 {
-    "$x";
+    no warnings 'void'; "$x";
 }
 
 $x->[0] = "\xff";

--- a/t/op/const-optree.t
+++ b/t/op/const-optree.t
@@ -456,6 +456,7 @@ for \%_ (@tests) {
                 "$nickname is$not inlinable";
     }
     if (exists $_{method}) {
+        no warnings 'once';
         local *time = $sub;
         $w = undef;
         use warnings 'ambiguous';

--- a/t/op/decl-refs.t
+++ b/t/op/decl-refs.t
@@ -67,15 +67,16 @@ for my $sigl ('$', '@', '%') {
     isnt ${$ret[0]}, \~::f, 'first retval of MY (\~f, ~g) is not \~::f';
     is $ret[1], \~g, '2nd retval of MY (\~f, ~g) is ~g';
     isnt $ret[1], \~::g, '2nd retval of MY (\~f, ~g) is not ~::g';
+    no warnings 'redefine';
     *MODIFY_SCALAR_ATTRIBUTES = sub {
-        is @_, 3, 'MY \~h : risible  calls handler with right no. of args';
-        is $_[2], 'risible', 'correct attr passed by MY \~h : risible';
+        is @_, 3, 'MY \~h : Risible  calls handler with right no. of args';
+        is $_[2], 'Risible', 'correct attr passed by MY \~h : Risible';
         return;
     };
     SKIP : {
         unless ('MY' eq 'local') {
             skip_if_miniperl "No attributes on miniperl", 2;
-            eval 'MY \~h : risible' or die $@ unless 'MY' eq 'local';
+            eval 'MY \~h : Risible' or die $@ unless 'MY' eq 'local';
         }
     }
     eval 'MY \~a ** 1';
@@ -84,21 +85,26 @@ for my $sigl ('$', '@', '%') {
        'comp error for MY \~a ** 1';
     $ret = MY \\~i;
     is $$ret, \~i, 'retval of MY \\~i is ref to ref to ~i';
-    $ret = MY \\~i;
-    isnt $$ret, \~::i, 'retval of MY \\~i is ref to ref to ~::i';
-    $ret = MY (\\~i);
-    is $$ret, \~i, 'retval of MY (\\~i) is ref to ref to ~i';
-    $ret = MY (\\~i);
-    isnt $$ret, \~::i, 'retval of MY (\\~i) is ref to ref to ~::i';
+    {
+        no warnings 'shadow';
+        $ret = MY \\~i;
+        isnt $$ret, \~::i, 'retval of MY \\~i is ref to ref to ~::i';
+        $ret = MY (\\~i);
+        is $$ret, \~i, 'retval of MY (\\~i) is ref to ref to ~i';
+        $ret = MY (\\~i);
+        isnt $$ret, \~::i, 'retval of MY (\\~i) is ref to ref to ~::i';
+    }
+    no warnings 'redefine';
+    no warnings 'void';
     *MODIFY_SCALAR_ATTRIBUTES = sub {
-        is @_, 3, 'MY (\~h) : bumpy  calls handler with right no. of args';
-        is $_[2], 'bumpy', 'correct attr passed by MY (\~h) : bumpy';
+        is @_, 3, 'MY (\~h) : Bumpy  calls handler with right no. of args';
+        is $_[2], 'Bumpy', 'correct attr passed by MY (\~h) : Bumpy';
         return;
     };
     SKIP : {
         unless ('MY' eq 'local') {
             skip_if_miniperl "No attributes on miniperl", 2;
-            eval 'MY (\~h) : bumpy' or die $@;
+            eval 'MY (\~h) : Bumpy' or die $@;
         }
     }
     1;

--- a/t/op/dor.t
+++ b/t/op/dor.t
@@ -55,11 +55,11 @@ for (qw(getc pos readline readlink undef umask <> <FOO> <$foo> -f)) {
 
 # Test for some ambiguous syntaxes
 
-eval q# sub f ($) { } f $x / 2; #;
+eval q# my $x = 1; sub f ($) { } f $x / 2; #;
 is( $@, '', "'/' correctly parsed as arithmetic operator" );
-eval q# sub f ($):lvalue { my $y } f $x /= 2; #;
+eval q# sub g ($):lvalue { my $y = 2 } g $x /= 2; #;
 is( $@, '', "'/=' correctly parsed as assignment operator" );
-eval q# sub f ($) { } f $x /2; #;
+eval q# sub h ($) { } h $x /2; #;
 like( $@, qr/^Search pattern not terminated/,
     "Caught unterminated search pattern error message: empty subroutine" );
 eval q# sub { my $fh; print $fh / 2 } #;
@@ -78,7 +78,7 @@ is(undef // 2, 2, 	'	// : left-hand operand optimized away');
 # Test that OP_DORs other branch isn't run when arg is defined
 # // returns the value if its defined, and we must test its
 # truthness after
-my $x = 0;
+$x = 0;
 my $y = 0;
 
 $x // 1 and $y = 1;

--- a/t/op/filetest_stack_ok.t
+++ b/t/op/filetest_stack_ok.t
@@ -17,39 +17,50 @@ plan( tests => @ops * 5 + 1 );
 package o { use overload '-X' => sub { 1 } }
 my $o = bless [], 'o';
 
-for my $op (@ops) {
-    ok( 1 == @{ [ eval "-$op 'TEST'" ] }, "-$op returns single value" );
-    ok( 1 == @{ [ eval "-$op *TEST" ] }, "-$op *gv returns single value" );
+{
+    no warnings 'unopened';
+    for my $op (@ops) {
+        ok( 1 == @{ [ eval "-$op 'TEST'" ] }, "-$op returns single value" );
+        if ($op eq 'l' ) {
+            no warnings 'io';
+            ok( 1 == @{ [ eval "-$op *TEST" ] }, "-$op *gv returns single value" );
+        }
+        else {
+            ok( 1 == @{ [ eval "-$op *TEST" ] }, "-$op *gv returns single value" );
+        }
 
-    my $count = 0;
-    my $t;
-    for my $m ("a", "b") {
-	if ($count == 0) {
-	    $t = eval "-$op _" ? 0 : "foo";
-	}
-	elsif ($count == 1) {
-	    is($m, "b", "-$op did not remove too many values from the stack");
-	}
-	$count++;
+        my $count = 0;
+        my $t;
+        for my $m ("a", "b") {
+            if ($count == 0) {
+                $t = eval "-$op _" ? 0 : "foo";
+            }
+            elsif ($count == 1) {
+                is($m, "b", "-$op did not remove too many values from the stack");
+            }
+            $count++;
+        }
+
+        $count = 0;
+        for my $m ("c", "d") {
+            if ($count == 0) {
+                $t = eval "-$op -e \$^X" ? 0 : "bar";
+            }
+            elsif ($count == 1) {
+                is($m, "d", "-$op -e \$^X did not remove too many values from the stack");
+            }
+            $count++;
+        }
+
+        my @foo = eval "-$op \$o";
+        is @foo, 1, "-$op \$overld did not leave \$overld on the stack";
     }
-
-    $count = 0;
-    for my $m ("c", "d") {
-	if ($count == 0) {
-	    $t = eval "-$op -e \$^X" ? 0 : "bar";
-	}
-	elsif ($count == 1) {
-	    is($m, "d", "-$op -e \$^X did not remove too many values from the stack");
-	}
-	$count++;
-    }
-
-    my @foo = eval "-$op \$o";
-    is @foo, 1, "-$op \$overld did not leave \$overld on the stack";
 }
 
 {
     # [perl #129347] cope with stacked filetests where PL_op->op_next is null
+    no warnings 'once';
+    no warnings 'uninitialized';
     () = sort { -d -d } \*TEST0, \*TEST1;
     ok 1, "survived stacked filetests with null op_next";
 }

--- a/t/op/flip.t
+++ b/t/op/flip.t
@@ -26,9 +26,9 @@ is($y, '12E0123E0');
 {
 local $.;
 
-open(of,'harness') or die "Can't open harness: $!";
+open(OF,'harness') or die "Can't open harness: $!";
 my $foo;
-while (<of>) {
+while (<OF>) {
     (3 .. 5) && ($foo .= $_);
 }
 $x = ($foo =~ y/\n/\n/);
@@ -40,6 +40,7 @@ ok(($x...$x) eq "1");
 
 {
     # coredump reported in bug 20001018.008 (#4474)
+    no warnings 'unopened';
     readline(UNKNOWN);
     $. = 1;
     $x = 1..10;

--- a/t/op/for.t
+++ b/t/op/for.t
@@ -3,6 +3,7 @@
 BEGIN {
     chdir 't' if -d 't';
     require "./test.pl";
+    set_up_inc(qw{../lib});
 }
 
 plan(126);
@@ -15,7 +16,7 @@ for (@array) {
     $r .= $_;
 }
 is ($r, 'ABC', 'Forwards for array');
-my $r = '';
+$r = '';
 for (1,2,3) {
     $r .= $_;
 }
@@ -549,7 +550,7 @@ for my $i (reverse (map {$_} @array, 1)) {
 }
 is ($r, '1CBA', 'Reverse for array and value via map with var');
 
-is do {17; foreach (1, 2) { 1; } }, '', "RT #1085: what should be output of perl -we 'print do { foreach (1, 2) { 1; } }'";
+is do {no warnings 'void'; 17; foreach (1, 2) { 1; } }, '', "RT #1085: what should be output of perl -we 'print do { foreach (1, 2) { 1; } }'";
 
 our $TODO;
 TODO: {

--- a/t/op/groups.t
+++ b/t/op/groups.t
@@ -136,7 +136,7 @@ sub Test {
         endgrent;
         skip "No group found we could add as a supplementary group", 1
             if (!@sup_group);
-        $) = "$) @sup_group[2]";
+        $) = "$) $sup_group[2]";
         my $ok = grep { $_ == $sup_group[2] } split ' ', $);
         ok $ok, "Group `$sup_group[0]' added as supplementary group";
     }

--- a/t/op/hexfp.t
+++ b/t/op/hexfp.t
@@ -14,98 +14,98 @@ plan(tests => 125);
 
 # Test hexfloat literals.
 
-is(0x0p0, 0);
-is(0x0.p0, 0);
-is(0x.0p0, 0);
-is(0x0.0p0, 0);
-is(0x0.00p0, 0);
+is(0x0p0, 0, '0x0p0');
+is(0x0.p0, 0, '0x0.p0');
+is(0x.0p0, 0, '0x.0p0');
+is(0x0.0p0, 0, '0x0.0p0');
+is(0x0.00p0, 0, '0x0.00p0');
 
-is(0x1p0, 1);
-is(0x1.p0, 1);
-is(0x1.0p0, 1);
-is(0x1.00p0, 1);
+is(0x1p0, 1, '0x1p0');
+is(0x1.p0, 1, '0x1.p0');
+is(0x1.0p0, 1, '0x1.0p0');
+is(0x1.00p0, 1, '0x1.00p0');
 
-is(0x2p0, 2);
-is(0x2.p0, 2);
-is(0x2.0p0, 2);
-is(0x2.00p0, 2);
+is(0x2p0, 2, '0x2p0');
+is(0x2.p0, 2, '0x2.p0');
+is(0x2.0p0, 2, '0x2.0p0');
+is(0x2.00p0, 2, '0x2.00p0');
 
-is(0x1p1, 2);
-is(0x1.p1, 2);
-is(0x1.0p1, 2);
-is(0x1.00p1, 2);
+is(0x1p1, 2, '0x1p1');
+is(0x1.p1, 2, '0x1.p1');
+is(0x1.0p1, 2, '0x1.0p1');
+is(0x1.00p1, 2, '0x1.00p1');
 
-is(0x.1p0, 0.0625);
-is(0x0.1p0, 0.0625);
-is(0x0.10p0, 0.0625);
-is(0x0.100p0, 0.0625);
+is(0x.1p0, 0.0625, '0x.1p0');
+is(0x0.1p0, 0.0625, '0x0.1p0');
+is(0x0.10p0, 0.0625, '0x0.10p0');
+is(0x0.100p0, 0.0625, '0x0.100p0');
 
-is(0x.1p0, 0.0625);
-is(0x1.1p0, 1.0625);
-is(0x1.11p0, 1.06640625);
-is(0x1.111p0, 1.066650390625);
+is(0x.1p0, 0.0625, '0x.1p0');
+is(0x1.1p0, 1.0625, '0x1.1p0');
+is(0x1.11p0, 1.06640625, '0x1.11p0');
+is(0x1.111p0, 1.066650390625, '0x1.111p0');
 
 # Positive exponents.
-is(0x1p2, 4);
-is(0x1p+2, 4);
-is(0x0p+0, 0);
+is(0x1p2, 4, '0x1p2');
+is(0x1p+2, 4, '0x1p+2');
+is(0x0p+0, 0, '0x0p+0');
 
 # Negative exponents.
-is(0x1p-1, 0.5);
-is(0x1.p-1, 0.5);
-is(0x1.0p-1, 0.5);
-is(0x0p-0, 0);
+is(0x1p-1, 0.5, '0x1p-1');
+is(0x1.p-1, 0.5, '0x1.p-1');
+is(0x1.0p-1, 0.5, '0x1.0p-1');
+is(0x0p-0, 0, '0x0p-0');
 
-is(0x1p+2, 4);
-is(0x1p-2, 0.25);
+is(0x1p+2, 4, '0x1p+2');
+is(0x1p-2, 0.25, '0x1p-2');
 
-is(0x3p+2, 12);
-is(0x3p-2, 0.75);
+is(0x3p+2, 12, '0x3p+2');
+is(0x3p-2, 0.75, '0x3p-2');
 
 # Shifting left.
-is(0x1p2, 1 << 2);
-is(0x1p3, 1 << 3);
-is(0x3p4, 3 << 4);
-is(0x3p5, 3 << 5);
-is(0x12p23, 0x12 << 23);
+is(0x1p2, 1 << 2, '0x1p2');
+is(0x1p3, 1 << 3, '0x1p3');
+is(0x3p4, 3 << 4, '0x3p4');
+is(0x3p5, 3 << 5, '0x3p5');
+is(0x12p23, 0x12 << 23, '0x12p23');
 
 # Shifting right.
-is(0x1p-2, 1 / (1 << 2));
-is(0x1p-3, 1 / (1 << 3));
-is(0x3p-4, 3 / (1 << 4));
-is(0x3p-5, 3 / (1 << 5));
-is(0x12p-23, 0x12 / (1 << 23));
+is(0x1p-2, 1 / (1 << 2), '0x1p-2');
+is(0x1p-3, 1 / (1 << 3), '0x1p-3');
+is(0x3p-4, 3 / (1 << 4), '0x3p-4');
+is(0x3p-5, 3 / (1 << 5), '0x3p-5');
+is(0x12p-23, 0x12 / (1 << 23), '0x12p-23');
 
 # Negative sign.
-is(-0x1p+2, -4);
-is(-0x1p-2, -0.25);
-is(-0x0p+0, 0);
-is(-0x0p-0, 0);
+is(-0x1p+2, -4, '-0x1p+2');
+is(-0x1p-2, -0.25, '-0x1p-2');
+is(-0x0p+0, 0, '-0x0p+0');
+is(-0x0p-0, 0, '-0x0p-0');
 
-is(0x0.10p0, 0.0625);
-is(0x0.1p0, 0.0625);
-is(0x.1p0, 0.0625);
+is(0x0.10p0, 0.0625, '0x0.10p0');
+is(0x0.1p0, 0.0625, '0x0.1p0');
+is(0x.1p0, 0.0625, '0x.1p0');
 
-is(0x12p+3, 144);
-is(0x12p-3, 2.25);
+is(0x12p+3, 144, '0x12p+3');
+is(0x12p-3, 2.25, '0x12p-3');
 
 # Hexdigits (lowercase).
-is(0x9p+0, 9);
-is(0xap+0, 10);
-is(0xfp+0, 15);
-is(0x10p+0, 16);
-is(0x11p+0, 17);
-is(0xabp+0, 171);
-is(0xab.cdp+0, 171.80078125);
+is(0x9p+0, 9, '0x9p+0');
+is(0xap+0, 10, '0xap+0');
+is(0xfp+0, 15, '0xfp+0');
+is(0x10p+0, 16, '0x10p+0');
+is(0x11p+0, 17, '0x11p+0');
+is(0xabp+0, 171, '0xabp+0');
+is(0xab.cdp+0, 171.80078125, '0xab.cdp+0');
 
 # Uppercase hexdigits and exponent prefix.
-is(0xAp+0, 10);
-is(0xFp+0, 15);
-is(0xABP+0, 171);
-is(0xAB.CDP+0, 171.80078125);
+is(0xAp+0, 10, '0xAp+0');
+is(0xFp+0, 15, '0xFp+0');
+is(0xABP+0, 171, '0xABP+0');
+is(0xAB.CDP+0, 171.80078125, '0xAB.CDP+0');
 
 # Underbars.
-is(0xa_b.c_dp+1_2, 703696);
+is(0xa_b.c_dp+1_2, 703696, '0xa_b.c_dp+1_2');
 
 # Note that the hexfloat representation is not unique since the
 # exponent can be shifted, and the hexdigits with it: this is no
@@ -116,15 +116,15 @@ is(0xa_b.c_dp+1_2, 703696);
 SKIP: {
     skip("nv_preserves_uv_bits is $Config{nv_preserves_uv_bits} not 53", 3)
         unless ($Config{nv_preserves_uv_bits} == 53);
-    is(0x0.b17217f7d1cf78p0, 0x1.62e42fefa39efp-1);
-    is(0x0.58b90bfbe8e7bcp1, 0x1.62e42fefa39efp-1);
-    is(0x0.2c5c85fdf473dep2, 0x1.62e42fefa39efp-1);
+    is(0x0.b17217f7d1cf78p0, 0x1.62e42fefa39efp-1, '0x0.b17217f7d1cf78p0');
+    is(0x0.58b90bfbe8e7bcp1, 0x1.62e42fefa39efp-1, '0x0.58b90bfbe8e7bcp1');
+    is(0x0.2c5c85fdf473dep2, 0x1.62e42fefa39efp-1, '0x0.2c5c85fdf473dep2');
 }
 
 # Needs to use within() instead of is() because of long doubles.
-within(0x1.99999999999ap-4, 0.1, 1e-9);
-within(0x3.333333333333p-5, 0.1, 1e-9);
-within(0xc.cccccccccccdp-7, 0.1, 1e-9);
+within(0x1.99999999999ap-4, 0.1, 1e-9, '0x1.99999999999ap-4');
+within(0x3.333333333333p-5, 0.1, 1e-9, '0x3.333333333333p-5');
+within(0xc.cccccccccccdp-7, 0.1, 1e-9, '0xc.cccccccccccdp-7');
 
 my $warn;
 
@@ -138,26 +138,26 @@ sub get_warn() {
 
 { # Test certain things that are not hexfloats and should stay that way.
     eval '0xp3';
-    like(get_warn(), qr/Missing operator before p3/);
+    like(get_warn(), qr/Missing operator before p3/, '0xp3');
 
     eval '5p3';
-    like(get_warn(), qr/Missing operator before p3/);
+    like(get_warn(), qr/Missing operator before p3/, '5p3');
 
     my @a;
     eval '@a = 0x3..5';
-    is("@a", "3 4 5");
+    is("@a", "3 4 5", '@a = 0x3..5');
 
     undef $a;
     eval '$a = eval "0x.3"';
-    is($a, undef); # throws an error
+    is($a, undef, '$a = eval "0x.3"'); # throws an error
 
     undef $a;
     eval '$a = eval "0xc.3"';
-    is($a, '123');
+    is($a, '123', '$a = eval "0xc.3"');
 
     undef $a;
     eval '$a = eval "0x.p3"';
-    is($a, undef);
+    is($a, undef, '$a = eval "0x.p3"');
 }
 
 # Test warnings.
@@ -166,79 +166,77 @@ SKIP:
     skip "nv_preserves_uv_bits is $Config{nv_preserves_uv_bits} not 53", 26
         unless $Config{nv_preserves_uv_bits} == 53;
 
-    local $^W = 1;
-
     eval '0x1_0000_0000_0000_0p0';
-    is(get_warn(), undef);
+    is(get_warn(), undef, '0x1_0000_0000_0000_0p0');
 
     eval '0x2_0000_0000_0000_0p0';
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '0x2_0000_0000_0000_0p0');
 
     eval '0x1.0000_0000_0000_0p0';
-    is(get_warn(), undef);
+    is(get_warn(), undef, '0x1.0000_0000_0000_0p0');
 
     eval '0x2.0000_0000_0000_0p0';
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '0x2.0000_0000_0000_0p0');
 
     eval '0x.1p-1021';
-    is(get_warn(), undef);
+    is(get_warn(), undef, '0x.1p-1021');
 
     eval '0x.1p-1023';
-    like(get_warn(), qr/^Hexadecimal float: exponent underflow/);
+    like(get_warn(), qr/^Hexadecimal float: exponent underflow/, '0x.1p-1023');
 
     eval '0x1.fffffffffffffp+1023';
-    is(get_warn(), undef);
+    is(get_warn(), undef, '0x1.fffffffffffffp+1023');
 
     eval '0x1.fffffffffffffp+1024';
-    like(get_warn(), qr/^Hexadecimal float: exponent overflow/);
+    like(get_warn(), qr/^Hexadecimal float: exponent overflow/, '0x1.fffffffffffffp+1024');
 
     undef $a;
     eval '$a = 0x111.0000000000000p+0'; # 12 zeros.
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
-    is($a, 273);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '$a = 0x111.0000000000000p+0');
+    is($a, 273, '$a = 0x111.0000000000000p+0');
 
     # The 13 zeros would be enough to push the hi-order digits
     # off the high-end.
 
     undef $a;
     eval '$a = 0x111.0000000000000p+0'; # 13 zeros.
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
-    is($a, 273);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '$a = 0x111.0000000000000p+0');
+    is($a, 273, '$a = 0x111.0000000000000p+0');
 
     undef $a;
     eval '$a = 0x111.00000000000000p+0'; # 14 zeros.
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
-    is($a, 273);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '$a = 0x111.00000000000000p+0');
+    is($a, 273, '$a = 0x111.00000000000000p+0');
 
     undef $a;
     eval '$a = 0xfffffffffffffp0'; # 52 bits.
-    is(get_warn(), undef);
-    is($a, 4.5035996273705e+15);
+    is(get_warn(), undef, '$a = 0xfffffffffffffp0');
+    is($a, 4.5035996273705e+15, '$a = 0xfffffffffffffp0');
 
     undef $a;
     eval '$a = 0xfffffffffffff.8p0'; # 53 bits.
-    is(get_warn(), undef);
-    is($a, 4.5035996273705e+15);
+    is(get_warn(), undef, '$a = 0xfffffffffffff.8p0');
+    is($a, 4.5035996273705e+15, '$a = 0xfffffffffffff.8p0');
 
     undef $a;
     eval '$a = 0xfffffffffffff.cp0'; # 54 bits.
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
-    is($a, 4.5035996273705e+15);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '$a = 0xfffffffffffff.cp0');
+    is($a, 4.5035996273705e+15, '$a = 0xfffffffffffff.cp0');
 
     undef $a;
     eval '$a = 0xf.ffffffffffffp0'; # 52 bits.
-    is(get_warn(), undef);
-    is($a, 16);
+    is(get_warn(), undef, '$a = 0xf.ffffffffffffp0');
+    is($a, 16, '$a = 0xf.ffffffffffffp0');
 
     undef $a;
     eval '$a = 0xf.ffffffffffff8p0'; # 53 bits.
-    is(get_warn(), undef);
-    is($a, 16);
+    is(get_warn(), undef, '$a = 0xf.ffffffffffff8p0');
+    is($a, 16, '$a = 0xf.ffffffffffff8p0');
 
     undef $a;
     eval '$a = 0xf.ffffffffffffcp0'; # 54 bits.
-    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/);
-    is($a, 16);
+    like(get_warn(), qr/^Hexadecimal float: mantissa overflow/, '$a = 0xf.ffffffffffffcp0');
+    is($a, 16, '$a = 0xf.ffffffffffffcp0');
 }
 
 # [perl #128919] limited exponent range in hex fp literal with long double
@@ -247,10 +245,10 @@ SKIP: {
         unless ($Config{uselongdouble} &&
 		($Config{nvsize} == 16 || $Config{nvsize} == 12) &&
 		($Config{long_double_style_ieee_extended}));
-    is(0x1p-1074,  4.94065645841246544e-324);
+    is(0x1p-1074,  4.94065645841246544e-324, '0x1p-1074');
     is(0x1p-1075,  2.47032822920623272e-324, '[perl #128919]');
-    is(0x1p-1076,  1.23516411460311636e-324);
-    is(0x1p-16445, 3.6451995318824746e-4951);
+    is(0x1p-1076,  1.23516411460311636e-324, '0x1p-1076');
+    is(0x1p-16445, 3.6451995318824746e-4951, '0x1p-16445');
 }
 
 # [perl #131894] parsing long binaryish floating point literals used to
@@ -258,24 +256,30 @@ SKIP: {
 SKIP: {
     skip("non-64-bit NVs or no 64-bit ints to test with", 3)
       unless $Config{nvsize} == 8 && $Config{d_double_style_ieee} && $Config{use64bitint};
-    is sprintf("%a", eval("0x030000000000000.1p0")), "0x1.8p+53";
-    is sprintf("%a", eval("01400000000000000000.1p0")), "0x1.8p+54";
-    is sprintf("%a", eval("0b110000000000000000000000000000000000000000000000000000000.1p0")), "0x1.8p+56";
+    is sprintf("%a", eval("0x030000000000000.1p0")),
+        "0x1.8p+53",
+        '0x1.8p+53';
+    is sprintf("%a", eval("01400000000000000000.1p0")),
+        "0x1.8p+54",
+        '0x1.8p+54';
+    is sprintf("%a", eval("0b110000000000000000000000000000000000000000000000000000000.1p0")),
+        "0x1.8p+56",
+        '0x1.8p+56';
 }
 
 # the implementation also allow for octal and binary fp
-is(01p0, 1);
-is(01.0p0, 1);
-is(01.00p0, 1);
-is(010.1p0, 8.125);
-is(00.400p1, 1);
-is(00p0, 0);
-is(01.1p0, 1.125);
+is(01p0, 1, '01p0');
+is(01.0p0, 1, '01.0p0');
+is(01.00p0, 1, '01.00p0');
+is(010.1p0, 8.125, '010.1p0');
+is(00.400p1, 1, '00.400p1');
+is(00p0, 0, '00p0');
+is(01.1p0, 1.125, '01.1p0');
 
-is(0b0p0, 0);
-is(0b1p0, 1);
-is(0b10p0, 2);
-is(0b1.1p0, 1.5);
+is(0b0p0, 0, '0b0p0');
+is(0b1p0, 1, '0b1p0');
+is(0b10p0, 2, '0b10p0');
+is(0b1.1p0, 1.5, '0b1.1p0');
 
 # previously these would pass "0x..." to the overload instead of the appropriate
 # "0b" or "0" prefix.

--- a/t/op/hexfp.t
+++ b/t/op/hexfp.t
@@ -116,6 +116,7 @@ is(0xa_b.c_dp+1_2, 703696, '0xa_b.c_dp+1_2');
 SKIP: {
     skip("nv_preserves_uv_bits is $Config{nv_preserves_uv_bits} not 53", 3)
         unless ($Config{nv_preserves_uv_bits} == 53);
+    no warnings 'overflow';
     is(0x0.b17217f7d1cf78p0, 0x1.62e42fefa39efp-1, '0x0.b17217f7d1cf78p0');
     is(0x0.58b90bfbe8e7bcp1, 0x1.62e42fefa39efp-1, '0x0.58b90bfbe8e7bcp1');
     is(0x0.2c5c85fdf473dep2, 0x1.62e42fefa39efp-1, '0x0.2c5c85fdf473dep2');
@@ -245,6 +246,7 @@ SKIP: {
         unless ($Config{uselongdouble} &&
 		($Config{nvsize} == 16 || $Config{nvsize} == 12) &&
 		($Config{long_double_style_ieee_extended}));
+    no warnings 'overflow';
     is(0x1p-1074,  4.94065645841246544e-324, '0x1p-1074');
     is(0x1p-1075,  2.47032822920623272e-324, '[perl #128919]');
     is(0x1p-1076,  1.23516411460311636e-324, '0x1p-1076');

--- a/t/op/index.t
+++ b/t/op/index.t
@@ -131,6 +131,8 @@ sub run_tests {
 
     SKIP: {
         skip("Not a 64-bit machine", 3) if length sprintf("%x", ~0) <= 8;
+        no warnings 'non_unicode';
+        no warnings 'portable';
         my $a = eval q{"\x{80000000}"};
         my $s = $a.'defxyz';
         is(index($s, 'def'), 1, "0x80000000 is a single character");
@@ -219,7 +221,7 @@ sub run_tests {
 
     # PVBM compilation should not flatten ref constants
     use constant riffraff => \our $referent;
-    index "foo", riffraff;
+    { no warnings 'void'; index "foo", riffraff; }
     is ref riffraff, 'SCALAR', 'index does not flatten ref constants';
 
     package o { use overload '""' => sub { "foo" } }
@@ -228,12 +230,12 @@ sub run_tests {
         'index respects changes in ref stringification';
 
     use constant quire => ${qr/(?{})/}; # A REGEXP, not a reference to one
-    index "foo", quire;
+    { no warnings 'void'; index "foo", quire; }
     eval ' "" =~ quire ';
     is $@, "", 'regexp constants containing code blocks are not flattened';
 
     use constant bang => $! = 8;
-    index "foo", bang;
+    { no warnings 'void'; index "foo", bang; }
     cmp_ok bang, '==', 8, 'dualvar constants are not flattened';
 
     use constant u => undef;
@@ -340,6 +342,7 @@ sub run_tests {
             sub STORE {
                 my ($self, $value) = @_;
 
+                no warnings 'closure';
                 $store = $value;
             }
         };

--- a/t/op/infnan.t
+++ b/t/op/infnan.t
@@ -25,7 +25,6 @@ my $PInf = "Inf"  + 0;
 my $NInf = "-Inf" + 0;
 my $NaN;
 {
-    local $^W = 0; # warning-ness tested later.
     $NaN  = "NaN" + 0;
 }
 
@@ -254,14 +253,14 @@ SKIP: {
     }
     for my $i (@FInf) {
         # Silence "isn't numeric in addition", that's kind of the point.
-        local $^W = 0;
+        no warnings 'numeric';
         cmp_ok("$i" + 0, '==', $PInf, "false infinity $i");
     }
 }
 
 {
     # Silence "Non-finite repeat count", that is tested elsewhere.
-    local $^W = 0;
+    no warnings 'numeric';
     is("a" x $PInf, "", "x +Inf");
     is("a" x $NInf, "", "x -Inf");
 }
@@ -282,7 +281,6 @@ ok($NaN eq $NaN, "NaN is NaN stringifically");
 is("$NaN", "NaN", "$NaN value stringifies as NaN");
 
 {
-    local $^W = 0; # warning-ness tested later.
     is("+NaN" + 0, "NaN", "+NaN is NaN");
     is("-NaN" + 0, "NaN", "-NaN is NaN");
 }
@@ -401,7 +399,7 @@ TODO: {
 SKIP: {
     my @FNaN = qw(NaX XNAN Ind Inx);
     # Silence "isn't numeric in addition", that's kind of the point.
-    local $^W = 0;
+    no warnings 'numeric';
     for my $i (@FNaN) {
         cmp_ok("$i" + 0, '==', 0, "false nan $i");
     }
@@ -409,7 +407,6 @@ SKIP: {
 
 {
     # Silence "Non-finite repeat count", that is tested elsewhere.
-    local $^W = 0;
     is("a" x $NaN, "", "x NaN");
 }
 
@@ -459,7 +456,6 @@ cmp_ok('-1e-9999', '==', 0,     "underflow to 0 (runtime) from neg");
 {
     my $w;
     local $SIG{__WARN__} = sub { $w = shift };
-    local $^W = 1;
 
     my $T =
         [

--- a/t/op/int.t
+++ b/t/op/int.t
@@ -40,7 +40,7 @@ my $y;
 }
 
 my @x = ( 6, 8, 10);
-cmp_ok($x["1foo"], '==', 8, 'check bad strings still get converted');
+{ no warnings 'numeric'; cmp_ok($x["1foo"], '==', 8, 'check bad strings still get converted'); }
 
 # 4,294,967,295 is largest unsigned 32 bit integer
 
@@ -77,6 +77,7 @@ cmp_ok($y, '==', 4745162525730, 'run time divison, result of about 42 bits');
 SKIP:
 {   # see #126635
     my $large;
+    no warnings 'portable';
     $large = eval "0xffff_ffff" if $Config::Config{ivsize} == 4;
     $large = eval "0xffff_ffff_ffff_ffff" if $Config::Config{ivsize} == 8;
     $large or skip "Unusual ivsize", 1;
@@ -85,5 +86,8 @@ SKIP:
     }
 }
 
-is(1+"0x10", 1, "check string '0x' prefix not treated as hex");
-is(1+"0b10", 1, "check string '0b' prefix not treated as binary");
+{
+    no warnings 'numeric';
+    is(1+"0x10", 1, "check string '0x' prefix not treated as hex");
+    is(1+"0b10", 1, "check string '0b' prefix not treated as binary");
+}

--- a/t/op/lc.t
+++ b/t/op/lc.t
@@ -19,14 +19,17 @@ use feature qw( fc );
 
 plan tests => 139 + 2 * (4 * 256) + 15;
 
-is(lc(undef),	   "", "lc(undef) is ''");
-is(lcfirst(undef), "", "lcfirst(undef) is ''");
-is(uc(undef),	   "", "uc(undef) is ''");
-is(ucfirst(undef), "", "ucfirst(undef) is ''");
+{
+    no warnings 'uninitialized';
+    is(lc(undef),	   "", "lc(undef) is ''");
+    is(lcfirst(undef), "", "lcfirst(undef) is ''");
+    is(uc(undef),	   "", "uc(undef) is ''");
+    is(ucfirst(undef), "", "ucfirst(undef) is ''");
+}
 
 {
     no feature 'fc';
-    is(CORE::fc(undef), "", "fc(undef) is ''");
+    { no warnings 'uninitialized'; is(CORE::fc(undef), "", "fc(undef) is ''"); }
     is(CORE::fc(''),    "", "fc('') is ''");
 
     local $@;
@@ -36,7 +39,7 @@ is(ucfirst(undef), "", "ucfirst(undef) is ''");
     {
         use feature 'fc';
         local $@;
-        eval { fc("eeyup") };
+        eval { no warnings 'void'; fc("eeyup") };
         ok(!$@, "...but works after requesting the feature");
     }
 }
@@ -262,27 +265,30 @@ for (1, 4, 9, 16, 25) {
        'fc U+03B0 grows threefold');
 }
 
-# bug #43207
-my $temp = "HellO";
-for ("$temp") {
-    lc $_;
-    is($_, "HellO", '[perl #43207] lc($_) modifying $_');
-}
-for ("$temp") {
-    fc $_;
-    is($_, "HellO", '[perl #43207] fc($_) modifying $_');
-}
-for ("$temp") {
-    uc $_;
-    is($_, "HellO", '[perl #43207] uc($_) modifying $_');
-}
-for ("$temp") {
-    ucfirst $_;
-    is($_, "HellO", '[perl #43207] ucfirst($_) modifying $_');
-}
-for ("$temp") {
-    lcfirst $_;
-    is($_, "HellO", '[perl #43207] lcfirst($_) modifying $_');
+{
+    # bug #43207
+    no warnings 'void';
+    my $temp = "HellO";
+    for ("$temp") {
+        lc $_;
+        is($_, "HellO", '[perl #43207] lc($_) modifying $_');
+    }
+    for ("$temp") {
+        fc $_;
+        is($_, "HellO", '[perl #43207] fc($_) modifying $_');
+    }
+    for ("$temp") {
+        uc $_;
+        is($_, "HellO", '[perl #43207] uc($_) modifying $_');
+    }
+    for ("$temp") {
+        ucfirst $_;
+        is($_, "HellO", '[perl #43207] ucfirst($_) modifying $_');
+    }
+    for ("$temp") {
+        lcfirst $_;
+        is($_, "HellO", '[perl #43207] lcfirst($_) modifying $_');
+    }
 }
 
 # new in Unicode 5.1.0

--- a/t/op/lex.t
+++ b/t/op/lex.t
@@ -257,6 +257,7 @@ SKIP:
     fresh_perl_is(
         "BEGIN{\$^H=hex ~0}\xF3",
         "Integer overflow in hexadecimal number at - line 1.\n"
+      . "Hexadecimal number > 0xffffffff non-portable at - line 1.\n"
       . "Malformed UTF-8 character: \\xf3 (too short; 1 byte available, need 4) at - line 1.\n"
       . "Malformed UTF-8 character (fatal) at - line 1.",
         {},

--- a/t/op/lex_assign.t
+++ b/t/op/lex_assign.t
@@ -18,6 +18,7 @@ my %h = (1..6);
 my $aref = \@a;
 my $href = \%h;
 open OP, qq{$runme -le "print 'aaa Ok ok' for 1..100"|};
+close OP;
 my $chopit = 'aaaaaa';
 my @chopar = (113 .. 119);
 my $posstr = '123456';
@@ -87,6 +88,7 @@ for (@INPUT) {
   my $undefed;
   my $xundefed = [];
   eval <<EOE;
+  no warnings 'shadow'; no warnings 'void'; no warnings 'syntax';
   local \$SIG{__WARN__} = \\&wrn;
   my \$a = 'fake';
   $integer;
@@ -184,6 +186,7 @@ EOE
 # above that use <DATA>.
 for my $glob (*__) {
   my ($y, $z);
+  no warnings 'uninitialized';
   $glob = $y x $z;
   { use integer; $glob = $y <=> $z; }
   $glob = $y cmp $z;
@@ -196,7 +199,7 @@ for my $glob (*__) {
 #     OPpTARGET_MY optimisation.  But where should it go?
 eval {
     sub PVBM () { 'foo' }
-    index 'foo', PVBM;
+    no warnings 'void'; index 'foo', PVBM;
     my $x = PVBM;
 
     my $str = 'foo';

--- a/t/op/list.t
+++ b/t/op/list.t
@@ -249,6 +249,7 @@ is(my $obj = tied($t)->{fetched}, undef, 'assignment to empty list makes no copi
 fresh_perl_is(<<'EOS', "", {}, "[perl #131954] heap use after free in pp_list");
 #!./perl
 BEGIN {
+no warnings 'void';
 my $bar = "bar";
 
 sub test_no_error {
@@ -256,15 +257,12 @@ sub test_no_error {
 }
 
 test_no_error($_) for split /\n/,
-q[	x
-	definfoo, $bar;
-	x
-	x
-	x
-	grep((not $bar, $bar, $bar), $bar);
-        x
-        x
+q[  x
+    definfoo, $bar;
     x
+    x
+    x
+    grep((not $bar, $bar, $bar), $bar);
         x
         x
         x
@@ -275,7 +273,10 @@ q[	x
         x
         x
         x
-       x
+        x
+        x
+        x
+        x
         x
         x
         x

--- a/t/op/loopctl.t
+++ b/t/op/loopctl.t
@@ -904,7 +904,7 @@ TEST39: {
 }
 cmp_ok($ok,'==',1,'nested constructs');
 
-sub test_last_label { last TEST40 }
+sub test_last_label { no warnings 'exiting'; last TEST40 }
 
 TEST40: {
     $ok = 1;
@@ -913,7 +913,7 @@ TEST40: {
 }
 cmp_ok($ok,'==',1,'dynamically scoped label');
 
-sub test_last { last }
+sub test_last { no warnings 'exiting'; last }
 
 TEST41: {
     $ok = 1;
@@ -1077,7 +1077,7 @@ last_113684:
     label1:
     {
         my $label = "label1";
-        eval { last $label };
+        eval { no warnings 'exiting'; last $label };
         fail("last with non-constant label");
         last last_113684;
     }
@@ -1088,7 +1088,7 @@ next_113684:
     label2:
     {
         my $label = "label2";
-        eval { next $label };
+        eval { no warnings 'exiting'; next $label };
         fail("next with non-constant label");
         next next_113684;
     }
@@ -1103,7 +1103,7 @@ redo_113684:
             pass("redo with non-constant label"); last redo_113684
         }
         my $label = "label3";
-        eval { redo $label };
+        eval { no warnings 'exiting'; redo $label };
         fail("redo with non-constant label");
     }
 }


### PR DESCRIPTION
This will be the first of a series of pull requests embodying work done to bring `t/op/*.t` into compliance with warnings-by-default (https://github.com/atoomic/perl/issues/309).  This file consists of 32 separate commits, most of which touch files in `/t/op` starting with letters 'a' through 'l'.

There are 2 files in that range that are left out of this p.r.:  `t/op/caller.t' and `t/op/local.t'.  See https://github.com/atoomic/perl/issues/339 for a discussion of the former.  As for the latter, over the past few days I sought to add descriptions to the many unit tests lacking them.  My initial motivation was simply to be able to locate places in the file where warnings were being generated.  Then it turned out that the mere act of adding descriptions to tests had bizarre results -- multiplying the number of tests actually being run!  I think I have solve that problem, but to keep review of this p.r. manageable, I've not included `t/op/local.t`.

To evaluate this p.r., try something like the following before-and-after commands.
**At HEAD of alpha-dev-03-warnings**
```
TEST_FILES="op/*.t" make test 2>&1 | tee /tmp/alpha-dev-03-warnings.t-op.make-test.output.txt
```
**After applying p.r.**
```
TEST_FILES="op/*.t" make test 2>&1 | tee /tmp/alpha-dev-03-warnings.after-p-r.t-op.make-test.output.txt
```
Thank you very much.
Jim Keenan