### PR TITLE
T op warnings group 2 20201212

### DIFF
--- a/t/op/magic.t
+++ b/t/op/magic.t
@@ -15,26 +15,27 @@ BEGIN {
 # does not mention any special variables, but that could easily change.
 BEGIN {
     # not available in miniperl
+    no warnings;
     my %non_mini = map { $_ => 1 } qw(+ - [);
     for (qw(
-	SIG ^OPEN ^TAINT ^UNICODE ^UTF8LOCALE ^WARNING_BITS 1 2 3 4 5 6 7 8
-	9 42 & ` ' : ? ! _ - [ ^ ~ = % . ( ) < > \ / $ | + ; ] ^A ^C ^D
-	^E ^F ^H ^I ^L ^N ^O ^P ^S ^T ^V ^W ^UTF8CACHE ::12345 main::98732
-	^LAST_FH
+        SIG ^OPEN ^TAINT ^UNICODE ^UTF8LOCALE ^WARNING_BITS 1 2 3 4 5 6 7 8
+        9 42 & ` ' : ? ! _ - [ ^ ~ = % . ( ) < > \ / $ | + ; ] ^A ^C ^D
+        ^E ^F ^H ^I ^L ^N ^O ^P ^S ^T ^V ^W ^UTF8CACHE ::12345 main::98732
+        ^LAST_FH
     )) {
-	my $v = $_;
-	# avoid using any global vars here:
-	if ($v =~ s/^\^(?=.)//) {
-	    for(substr $v, 0, 1) {
-		$_ = chr(utf8::native_to_unicode(ord($_)) - 64);
-	    }
-	}
-	SKIP:
-	{
-	    skip_if_miniperl("the module for *$_ may not be available in "
-			     . "miniperl", 1) if $non_mini{$_};
-	    ok defined *$v, "*$_ appears to be defined at the outset";
-	}
+        my $v = $_;
+        # avoid using any global vars here:
+        if ($v =~ s/^\^(?=.)//) {
+            for(substr $v, 0, 1) {
+                $_ = chr(utf8::native_to_unicode(ord($_)) - 64);
+            }
+        }
+        SKIP:
+        {
+            skip_if_miniperl("the module for *$_ may not be available in "
+                . "miniperl", 1) if $non_mini{$_};
+            ok defined *$v, "*$_ appears to be defined at the outset";
+        }
     }
 }
 
@@ -70,11 +71,11 @@ sub env_is {
     if ($Is_MSWin32) {
         # cmd.exe will echo 'variable=value' but 4nt will echo just the value
         # -- Nikola Knezevic
-	require Win32;
-	my $cp = Win32::GetConsoleOutputCP();
-	Win32::SetConsoleOutputCP(Win32::GetACP());
+        require Win32;
+        my $cp = Win32::GetConsoleOutputCP();
+        Win32::SetConsoleOutputCP(Win32::GetACP());
         (my $set = `set $key 2>nul`) =~ s/\r\n$/\n/;
-	Win32::SetConsoleOutputCP($cp);
+        Win32::SetConsoleOutputCP($cp);
         like $set, qr/^(?:\Q$key\E=)?\Q$val\E$/, $desc;
     } elsif ($Is_VMS) {
         my $eqv = `write sys\$output f\$trnlnm("\Q$key\E")`;
@@ -93,7 +94,7 @@ sub env_is {
 }
 
 END {
-    # On VMS, environment variable changes are peristent after perl exits
+    # On VMS, environment variable changes are persistent after perl exits
     if ($Is_VMS) {
         delete $ENV{'FOO'};
         delete $ENV{'__NoNeSuCh'};
@@ -104,9 +105,10 @@ END {
 eval '$ENV{"FOO"} = "hi there";';	# check that ENV is inited inside eval
 # cmd.exe will echo 'variable=value' but 4nt will echo just the value
 # -- Nikola Knezevic
-if ($Is_MSWin32)  { like `set FOO`, qr/^(?:FOO=)?hi there$/m; }
-elsif ($Is_VMS)   { is `write sys\$output f\$trnlnm("FOO")`, "hi there\n"; }
-else              { is `echo \$FOO`, "hi there\n"; }
+my $desc = "Got OS-appropriate 'hi there'";
+if ($Is_MSWin32)  { like `set FOO`, qr/^(?:FOO=)?hi there$/m, $desc; }
+elsif ($Is_VMS)   { is `write sys\$output f\$trnlnm("FOO")`, "hi there\n", $desc; }
+else              { is `echo \$FOO`, "hi there\n", $desc; }
 
 unlink_all 'ajslkdfpqjsjfk';
 $! = 0;
@@ -116,11 +118,11 @@ close FOO; # just mention it, squelch used-only-once
 
 SKIP: {
     skip('SIGINT not safe on this platform', 5)
-	if $Is_MSWin32 || $Is_NetWare || $Is_Dos;
-  # the next tests are done in a subprocess because sh spits out a
-  # newline onto stderr when a child process kills itself with SIGINT.
-  # We use a pipe rather than system() because the VMS command buffer
-  # would overflow with a command that long.
+        if $Is_MSWin32 || $Is_NetWare || $Is_Dos;
+    # the next tests are done in a subprocess because sh spits out a
+    # newline onto stderr when a child process kills itself with SIGINT.
+    # We use a pipe rather than system() because the VMS command buffer
+    # would overflow with a command that long.
 
     # For easy interpolation of test numbers:
     my $next_test = curr_test() - 1;
@@ -135,16 +137,16 @@ SKIP: {
     $| = 1;		# command buffering
 
     $SIG{"INT"} = "ok1";     kill "INT",$$; sleep 1;
-    $SIG{"INT"} = "IGNORE";  kill "INT",$$; sleep 1; print "ok $t2\n";
-    $SIG{"INT"} = "DEFAULT"; kill "INT",$$; sleep 1; print" not ok $t2\n";
+    $SIG{"INT"} = "IGNORE";  kill "INT",$$; sleep 1; print "ok $t2 - IGNORE\n";
+    $SIG{"INT"} = "DEFAULT"; kill "INT",$$; sleep 1; print" not ok $t2 - DEFAULT\n";
 
     sub ok1 {
-	if ((my $x = pop(@_)) eq "INT") {
-	    print "ok $t1\n";
-	}
-	else {
-	    print "not ok $t1 ($x @_)\n";
-	}
+        if ((my $x = pop(@_)) eq "INT") {
+            print "ok $t1 - $x\n";
+        }
+        else {
+            print "not ok $t1 ($x @_)\n";
+        }
     }
 
 END
@@ -155,38 +157,39 @@ END
     print CMDPIPE "my \$t3 = $tn[3];\n", <<'END';
 
     { package X;
-	sub DESTROY {
-	    kill "INT",$$;
-	}
+        sub DESTROY {
+            kill "INT",$$;
+        }
     }
     sub x {
-	my $x=bless [], 'X';
-	return sub { $x };
+        my $x=bless [], 'X';
+        return sub { $x };
     }
     $| = 1;		# command buffering
     $SIG{"INT"} = "ok3";
     {
-	local $SIG{"INT"}=x();
-	print ""; # Needed to expose failure in 5.8.0 (why?)
+        local $SIG{"INT"}=x();
+        print ""; # Needed to expose failure in 5.8.0 (why?)
     }
     sleep 1;
     delete $SIG{"INT"};
     kill "INT",$$; sleep 1;
     sub ok3 {
-	print "ok $t3\n";
+        print "ok $t3 - after kill\n";
     }
 END
     close CMDPIPE;
     $? >>= 8 if $^O eq 'VMS'; # POSIX status hiding in 2nd byte
     my $todo = ($^O eq 'os2' ? ' # TODO: EMX v0.9d_fix4 bug: wrong nibble? ' : '');
     $todo = ($Config{usecrosscompile} ? '# TODO: Not sure whats going on here when cross-compiling' : '');
-    print $? & 0xFF ? "ok $tn[4]$todo\n" : "not ok $tn[4]$todo\n";
+    my $desc = 'bitmask child error';
+    print $? & 0xFF ? "ok $tn[4] - $desc $todo\n" : "not ok $tn[4] - $desc $todo\n";
 
     open(CMDPIPE, "|-", $PERL);
     print CMDPIPE <<'END';
 
     sub PVBM () { 'foo' }
-    index 'foo', PVBM;
+    my $idx = index 'foo', PVBM;
     my $pvbm = PVBM;
 
     sub foo { exit 0 }
@@ -196,7 +199,8 @@ END
 END
     close CMDPIPE;
     $? >>= 8 if $^O eq 'VMS';
-    print $? ? "not ok $tn[5]\n" : "ok $tn[5]\n";
+    $desc = 'No child error after CMDPIPE';
+    print $? ? "not ok $tn[5] - $desc\n" : "ok $tn[5] - $desc\n";
 
     curr_test(curr_test() + 5);
 }
@@ -204,8 +208,8 @@ END
 # can we slice ENV?
 my @val1 = @ENV{keys(%ENV)};
 my @val2 = values(%ENV);
-is join(':',@val1), join(':',@val2);
-cmp_ok @val1, '>', 1;
+is join(':',@val1), join(':',@val2), "Got expected values in \%ENV";
+cmp_ok @val1, '>', 1, "Got " . scalar(@val1) . " elements";
 
 # deleting $::{ENV}
 is runperl(prog => 'delete $::{ENV}; chdir; print qq-ok\n-'), "ok\n",
@@ -213,50 +217,50 @@ is runperl(prog => 'delete $::{ENV}; chdir; print qq-ok\n-'), "ok\n",
 
 # regex vars
 'foobarbaz' =~ /b(a)r/;
-is $`, 'foo';
-is $&, 'bar';
-is $', 'baz';
-is $+, 'a';
+is $`, 'foo', '$PREMATCH';
+is $&, 'bar', '$MATCH';
+is $', 'baz', '$POSTMATCH';
+is $+, 'a', '$LAST_PAREN_MATCH';
 
 # [perl #24237]
 for (qw < ` & ' >) {
  fresh_perl_is
-  qq < \@$_; q "fff" =~ /(?!^)./; print "[\$$_]\\n" >,
+  qq < no warnings 'void'; \@$_; q "fff" =~ /(?!^)./; print "[\$$_]\\n" >,
   "[f]\n", {},
   "referencing \@$_ before \$$_ etc. still saws off ampersands";
 }
 
 # $"
 my @a = qw(foo bar baz);
-is "@a", "foo bar baz";
+is "@a", "foo bar baz", 'Got expected array interpolation';
 {
     local $" = ',';
-    is "@a", "foo,bar,baz";
+    is "@a", "foo,bar,baz", 'Got expected array interpolation: $"';
 }
 
 # $;
 my %h = ();
 $h{'foo', 'bar'} = 1;
-is((keys %h)[0], "foo\034bar");
+is((keys %h)[0], "foo\034bar", 'Got expected key');
 {
     local $; = 'x';
     %h = ();
     $h{'foo', 'bar'} = 1;
-    is((keys %h)[0], 'fooxbar');
+    is((keys %h)[0], 'fooxbar', 'Got expected key: $;');
 }
 
 # $?, $@, $$
 system qq[$PERL "-I../lib" -e "use vmsish qw(hushed); exit(0)"];
-is $?, 0;
+is $?, 0, 'child error zero';
 system qq[$PERL "-I../lib" -e "use vmsish qw(hushed); exit(1)"];
-isnt $?, 0;
+isnt $?, 0, 'child error non-zero';
 
 eval { die "foo\n" };
-is $@, "foo\n";
+is $@, "foo\n", 'Got expected eval error';
 
 ok !*@{HASH}, 'no %@';
 
-cmp_ok($$, '>', 0);
+cmp_ok($$, '>', 0, '$PID non-zero');
 my $pid = $$;
 eval { $$ = 42 };
 is $$, 42, '$$ can be modified';
@@ -264,14 +268,14 @@ SKIP: {
     skip "no fork", 1 unless $Config{d_fork};
     (my $kidpid = open my $fh, "-|") // skip "cannot fork: $!", 1;
     if($kidpid) { # parent
-	my $kiddollars = <$fh>;
-	close $fh or die "cannot close pipe from kid proc: $!";
-	is $kiddollars, $kidpid, '$$ is reset on fork';
+        my $kiddollars = <$fh>;
+        close $fh or die "cannot close pipe from kid proc: $!";
+        is $kiddollars, $kidpid, '$$ is reset on fork';
     }
     else { # child
-	print $$;
-	$::NO_ENDING = $::NO_ENDING = 1; # silence "Looks like you only ran..."
-	exit;
+        print $$;
+        $::NO_ENDING = $::NO_ENDING = 1; # silence "Looks like you only ran..."
+        exit;
     }
 }
 $$ = $pid; # Tests below use $$
@@ -282,7 +286,7 @@ $$ = $pid; # Tests below use $$
       || $Config{usensgetexecutablepath};
     my $wd;
     if ($^O eq 'qnx') {
-	chomp($wd = `/usr/bin/fullpath -t`);
+        chomp($wd = `/usr/bin/fullpath -t`);
     }
     elsif($^O =~ /android/) {
         chomp($wd = `sh -c 'pwd'`);
@@ -293,14 +297,14 @@ $$ = $pid; # Tests below use $$
        $wd =~ s#/t$##;
        $wd =~ /(.*)/; $wd = $1; # untaint
        if ($Is_Cygwin) {
-	   $wd = Cygwin::win_to_posix_path(Cygwin::posix_to_win_path($wd, 1));
+           $wd = Cygwin::win_to_posix_path(Cygwin::posix_to_win_path($wd, 1));
        }
     }
     elsif($Is_os2) {
        $wd = Cwd::sys_cwd();
     }
     else {
-	$wd = '.';
+        $wd = '.';
     }
     my $perl = $Is_VMS || $is_abs ? $^X : "$wd/perl";
     my $headmaybe = '';
@@ -308,18 +312,18 @@ $$ = $pid; # Tests below use $$
     my $tailmaybe = '';
     my $script = "$wd/show-shebang";
     if ($Is_MSWin32) {
-	chomp($wd = `cd`);
-	$wd =~ s|\\|/|g;
-	$perl = "$wd/perl.exe";
-	$script = "$wd/show-shebang.bat";
-	$headmaybe = <<EOH ;
+        chomp($wd = `cd`);
+        $wd =~ s|\\|/|g;
+        $perl = "$wd/perl.exe";
+        $script = "$wd/show-shebang.bat";
+        $headmaybe = <<EOH ;
 \@rem ='
 \@echo off
 $perl -x \%0
 goto endofperl
 \@rem ';
 EOH
-	$tailmaybe = <<EOT ;
+        $tailmaybe = <<EOT ;
 
 __END__
 :endofperl
@@ -338,64 +342,64 @@ $0 = Cygwin::win_to_posix_path(Cygwin::posix_to_win_path($0, 1));
 EOX
     }
     if ($^O eq 'os390' or $^O eq 'posix-bc') {  # no shebang
-	$headmaybe = <<EOH ;
+        $headmaybe = <<EOH ;
     eval 'exec ./perl -S \$0 \${1+"\$\@"}'
         if 0;
 EOH
     }
     my $s1 = "\$^X is $perl, \$0 is $script\n";
-    ok open(SCRIPT, ">$script") or diag "Can't write to $script: $!";
-    ok print(SCRIPT $headmaybe . <<EOB . $middlemaybe . <<'EOF' . $tailmaybe) or diag $!;
+    ok (open(SCRIPT, ">$script"), "Able to open") or diag "Can't write to $script: $!";
+    ok (print(SCRIPT $headmaybe . <<EOB . $middlemaybe . <<'EOF' . $tailmaybe), "Able to print") or diag $!;
 #!$perl
 EOB
 print "\$^X is $^X, \$0 is $0\n";
 EOF
-    ok close(SCRIPT) or diag $!;
-    ok chmod(0755, $script) or diag $!;
+    ok (close(SCRIPT), "Able to close") or diag $!;
+    ok (chmod(0755, $script), "Able to chmod") or diag $!;
     $_ = $Is_VMS ? `$perl -x $script` : `$script`;
     s/\.exe//i if $Is_Dos or $Is_Cygwin or $Is_os2;
     s{is perl}{is $perl}; # for systems where $^X is only a basename
     s{\\}{/}g;
     if ($Is_MSWin32 || $Is_os2) {
-	      is( uc $_, uc $s1, '$0 and $^X for win32/os2 (1)');
+        is( uc $_, uc $s1, '$0 and $^X for win32/os2 (1)');
     } else {
   SKIP:
      {
-	      skip "# TODO: Hit bug posix-2058; exec does not setup argv[0] correctly." if ($^O eq "vos");
-	      is( $_, $s1, '$0 and $^X for anything but win32/os2 (1)');
+      skip "# TODO: Hit bug posix-2058; exec does not setup argv[0] correctly." if ($^O eq "vos");
+      is( $_, $s1, '$0 and $^X for anything but win32/os2 (1)');
      }
     }
     $_ = `$perl -x $script`;
     s/\.exe//i if $Is_Dos or $Is_os2 or $Is_Cygwin;
     s{\\}{/}g;
     if ($Is_MSWin32 || $Is_os2) {
-	      is( uc $_, uc $s1, '$0 and $^X for win32/os2 (2)');
+      is( uc $_, uc $s1, '$0 and $^X for win32/os2 (2)');
     } else {
-	      is( $_, $s1, '$0 and $^X for anything but win32/os2 (2)');
+      is( $_, $s1, '$0 and $^X for anything but win32/os2 (2)');
     }
-    ok unlink($script) or diag $!;
+    ok (unlink($script), "Able to unlink") or diag $!;
     # CHECK
     # Could this be replaced with:
     # unlink_all($script);
 }
 
 # $], $^O, $^T
-cmp_ok $], '>=', 5.00319;
-ok $^O;
-cmp_ok $^T, '>', 850000000;
+cmp_ok $], '>=', 5.00319, "\$] is $]";
+ok $^O, "\$^O is $^O";
+cmp_ok $^T, '>', 850000000, "\$^T is $^T";
 
 # Test change 25062 is working
 my $orig_osname = $^O;
 {
-local $^I = '.bak';
-is $^O, $orig_osname, 'Assigning $^I does not clobber $^O';
+    local $^I = '.bak';
+    is $^O, $orig_osname, 'Assigning $^I does not clobber $^O';
 }
 $^O = $orig_osname;
 
 {
     #RT #72422
     foreach my $p (0, 1) {
-	fresh_perl_is(<<"EOP", '2 4 8', undef, "test \$^P = $p");
+        fresh_perl_is(<<"EOP", '2 4 8', undef, "test \$^P = $p");
 \$DB::single = 2;
 \$DB::trace = 4;
 \$DB::signal = 8;
@@ -444,23 +448,21 @@ our $TODO;
     local $SIG{'__WARN__'} = sub { $ok = 0; $warn = join '', @_; $warn =~ s/\n$//; };
     $! = undef;
     local $TODO = $Is_VMS ? "'\$!=undef' does throw a warning" : '';
-    ok($ok, $warn);
+    ok($ok, "<$warn>");
 }
 
 SKIP: {
     skip_if_miniperl("miniperl can't rely on loading %Errno", 2);
    no warnings 'void';
 
-# Make sure Errno hasn't been prematurely autoloaded
-
-   ok !keys %Errno::;
+   ok !keys %Errno::, "Errno hasn't been prematurely autoloaded";
 
 # Test auto-loading of Errno when %! is used
 
    ok scalar eval q{
       %!;
       scalar %Errno::;
-   }, $@;
+   }, "<$@>";
 }
 
 SKIP:  {
@@ -476,7 +478,7 @@ SKIP:  {
     {
         no strict 'refs';
         %errs = %{"!"}; # Cause Errno.pm to be loaded at run-time
-        ok ${"!"}{ENOENT};
+        ok ${"!"}{ENOENT}, "Errno.pm loaded at runtime";
     }
 
     # Make sure defined(*{"!"}) before %! does not stop %! from working
@@ -492,59 +494,61 @@ SKIP:  {
 foreach (['powie::!', 'Errno']) {
     my ($symbol, $package) = @$_;
     SKIP: {
-	(my $extension = $package) =~ s|::|/|g;
-	skip "$package is statically linked", 2
-	    if $Config{static_ext} =~ m|\b\Q$extension\E\b|;
-	foreach my $scalar_first ('', '$$symbol;') {
-        no strict 'refs';
-	    my $desc = qq{Referencing %{"$symbol"}};
-	    $desc .= qq{ after mentioning \${"$symbol"}} if $scalar_first;
-	    $desc .= " doesn't load $package";
+        (my $extension = $package) =~ s|::|/|g;
+        skip "$package is statically linked", 2
+            if $Config{static_ext} =~ m|\b\Q$extension\E\b|;
+        foreach my $scalar_first ('', '$$symbol;') {
+            no strict 'refs';
+            my $desc = qq{Referencing %{"$symbol"}};
+            $desc .= qq{ after mentioning \${"$symbol"}} if $scalar_first;
+            $desc .= " doesn't load $package";
 
-	    fresh_perl_is(<<"EOP", 0, {}, $desc);
+            fresh_perl_is(<<"EOP", 0, {}, $desc);
 my \$symbol = '$symbol';
 no strict 'refs';
+no warnings 'void';
 $scalar_first;
 1 if %{\$symbol};
 print scalar %${package}::;
 EOP
-	}
+        }
     }
 }
 
-is $^S, 0;
-eval { is $^S,1 };
-eval " BEGIN { ok ! defined \$^S } ";
-is $^S, 0;
+is $^S, 0, "\$^S has value 0";
+eval { is $^S,1, 'Per $^S, interpreter is executing an eval' };
+eval " BEGIN { ok ! defined \$^S, 'Per \$^S, interpreter is parsing module, eval, or main program' } ";
+is $^S, 0, "\$^S has value 0";
 
 my $taint = ${^TAINT};
-is ${^TAINT}, $taint;
+is ${^TAINT}, $taint, 'Got expected value of ${^TAINT}';
 eval { ${^TAINT} = 1 };
-is ${^TAINT}, $taint;
+is ${^TAINT}, $taint, 'Got expected value of ${^TAINT}';
 
 # 5.6.1 had a bug: @+ and @- were not properly interpolated
 # into double-quoted strings
 # 20020414 mjd-perl-patch+@plover.com
 "I like pie" =~ /(I) (like) (pie)/;
-is "@-",  "0 0 2 7";
-is "@+", "10 1 6 10";
+is "@-",  "0 0 2 7",  'Got expected interpolation of @-';
+is "@+", "10 1 6 10", 'Got expected interpolation of @+';
 
 # Tests for the magic get of $\
 {
+    my $desc = "RT 19330 / GH 6176";
     my $ok = 0;
     # [perl #19330]
     {
-	local $\ = undef;
-	$\++; $\++;
-	$ok = $\ eq 2;
+        local $\ = undef;
+        $\++; $\++;
+        $ok = $\ eq 2;
     }
-    ok $ok;
+    ok $ok, $desc;
     $ok = 0;
     {
-	local $\ = "a\0b";
-	$ok = "a$\b" eq "aa\0bb";
+        local $\ = "a\0b";
+        $ok = "a$\b" eq "aa\0bb";
     }
-    ok $ok;
+    ok $ok, $desc;
 }
 
 # Test for bug [perl #36434]
@@ -554,6 +558,7 @@ our (@ISA, %ENV);
 SKIP: {
     skip('Can\'t make assignment to \%ENV on this system', 3) if $Is_VMS;
 
+    note("RT 36434 / GH 7999");
     local @ISA;
     local %ENV;
     # This used to be __PACKAGE__, but that causes recursive
@@ -653,17 +658,28 @@ is ${^LAST_FH}, undef, '${^LAST_FH} is undef when PL_last_in_gv is NULL';
 # assert when referenced by the magic for ${^LAST_FH}.
 # The approach to fixing this has changed (#128263), but it's still useful
 # to check each op.
-for my $code ('tell $0', 'sysseek $0, 0, 0', 'seek $0, 0, 0', 'eof $0') {
-    fresh_perl_is("$code; print defined \${^LAST_FH} ? qq(not ok\n) : qq(ok\n)", "ok\n",
-                  undef, "check $code doesn't define \${^LAST_FH}");
+my @funcs2warns = (
+    [ 'tell $0'             => q|no warnings 'void'; no warnings 'unopened';| ],
+    [ 'sysseek $0, 0, 0'    => q|no warnings 'unopened';| ],
+    [ 'seek $0, 0, 0'       => q|no warnings 'unopened';| ],
+    [ 'eof $0'              => q|no warnings 'void';| ],
+);
+for my $code (@funcs2warns) {
+    fresh_perl_is(
+        "$code->[1] $code->[0]; print defined \${^LAST_FH} ? qq(not ok\n) : qq(ok\n)",
+        "ok\n",
+        undef,
+        "check $code->[0] doesn't define \${^LAST_FH}");
 }
 
 # $|
 fresh_perl_is 'print $| = ~$|', "1\n", {switches => ['-l']},
- '[perl #4760] print $| = ~$|';
+ '[perl #4760] [gh #2890] print $| = ~$|';
 fresh_perl_is
- 'no strict q|refs|; select f; undef *f; ${q/|/}; print STDOUT qq|ok\n|', "ok\n", {},
- '[perl #115206] no crash when vivifying $| while *{+select}{IO} is undef';
+ 'no strict q|refs|; no warnings q|reserved|; no warnings q|void|; select f; undef *f; ${q/|/}; print STDOUT qq|ok\n|',
+ "ok\n",
+ {},
+ '[perl #115206] [gh #12478] no crash when vivifying $| while *{+select}{IO} is undef';
 
 # ${^OPEN} and $^H interaction
 # Setting ${^OPEN} causes $^H to change, but setting $^H would only some-
@@ -726,101 +742,104 @@ is ++${^MPEN}, 1, '${^MPEN} can be incremented';
 
 SKIP: {
     skip("%ENV manipulations fail or aren't safe on $^O", 20)
-	if $Is_Dos;
+    if $Is_Dos;
     skip "Win32 needs XS for env/shell tests", 20
         if $Is_MSWin32 && is_miniperl;
 
  SKIP: {
-	skip("clearing \%ENV is not safe when running under valgrind or on VMS")
-	    if $ENV{PERL_VALGRIND} || $Is_VMS;
+    skip("clearing \%ENV is not safe when running under valgrind or on VMS")
+        if $ENV{PERL_VALGRIND} || $Is_VMS;
 
-	    my $PATH = $ENV{PATH};
-	    my $SYSTEMROOT = $ENV{SYSTEMROOT} if exists $ENV{SYSTEMROOT}; # win32
-	    my $PDL = $ENV{PERL_DESTRUCT_LEVEL} || 0;
-	    $ENV{foo} = "bar";
-	    %ENV = ();
-	    $ENV{PATH} = $PATH;
-	    $ENV{SYSTEMROOT} = $SYSTEMROOT if defined $SYSTEMROOT;
-	    $ENV{PERL_DESTRUCT_LEVEL} = $PDL || 0;
-	    if ($Is_MSWin32) {
-		is `set foo 2>NUL`, "";
-	    } else {
-		is `echo \$foo`, "\n";
-	    }
-	}
+        my $PATH = $ENV{PATH};
+        my $SYSTEMROOT = $ENV{SYSTEMROOT} if exists $ENV{SYSTEMROOT}; # win32
+        my $PDL = $ENV{PERL_DESTRUCT_LEVEL} || 0;
+        $ENV{foo} = "bar";
+        %ENV = ();
+        $ENV{PATH} = $PATH;
+        $ENV{SYSTEMROOT} = $SYSTEMROOT if defined $SYSTEMROOT;
+        $ENV{PERL_DESTRUCT_LEVEL} = $PDL || 0;
+        my $desc = 'Got expected backtick output';
+        if ($Is_MSWin32) {
+            is `set foo 2>NUL`, "", $desc;
+        } else {
+            is `echo \$foo`, "\n", $desc;
+        }
+    }
 
-	$ENV{__NoNeSuCh} = 'foo';
-	$0 = 'bar';
-	env_is(__NoNeSuCh => 'foo', 'setting $0 does not break %ENV');
+    $ENV{__NoNeSuCh} = 'foo';
+    $0 = 'bar';
+    env_is(__NoNeSuCh => 'foo', 'setting $0 does not break %ENV');
 
-	$ENV{__NoNeSuCh2} = 'foo';
-	$ENV{__NoNeSuCh2} = undef;
-	env_is(__NoNeSuCh2 => '', 'setting a key as undef does not delete it');
+    $ENV{__NoNeSuCh2} = 'foo';
+    $ENV{__NoNeSuCh2} = undef;
+    env_is(__NoNeSuCh2 => '', 'setting a key as undef does not delete it');
 
-	# stringify a glob
-	$ENV{foo} = *TODO;
-	env_is(foo => '*main::TODO', 'ENV store of stringified glob');
+    # stringify a glob
+    $ENV{foo} = *TODO;
+    env_is(foo => '*main::TODO', 'ENV store of stringified glob');
 
-	# stringify a ref
-	my $ref = [];
-	$ENV{foo} = $ref;
-	env_is(foo => "$ref", 'ENV store of stringified ref');
+    # stringify a ref
+    my $ref = [];
+    $ENV{foo} = $ref;
+    env_is(foo => "$ref", 'ENV store of stringified ref');
 
-	# downgrade utf8 when possible
-	my $bytes = "eh zero \x{A0}";
+    # downgrade utf8 when possible
+    my $bytes = "eh zero \x{A0}";
     my $chars;
-	utf8::upgrade($chars = $bytes);
-	my $forced = $ENV{foo} = $chars;
-	ok(!utf8::is_utf8($forced) && $forced eq $bytes, 'ENV store downgrades utf8 in SV');
-	env_is(foo => $bytes, 'ENV store downgrades utf8 in setenv');
+    utf8::upgrade($chars = $bytes);
+    my $forced = $ENV{foo} = $chars;
+    ok(!utf8::is_utf8($forced) && $forced eq $bytes, 'ENV store downgrades utf8 in SV');
+    env_is(foo => $bytes, 'ENV store downgrades utf8 in setenv');
 
-	# warn when downgrading utf8 is not possible
-	$chars = "X-Day \x{1998}";
-	utf8::encode($bytes = $chars);
-	{
-	  my $warned = 0;
-	  local $SIG{__WARN__} = sub { ++$warned if $_[0] =~ /^Wide character in setenv/; print "# @_" };
-	  $forced = $ENV{foo} = $chars;
-	  ok($warned == 1, 'ENV store warns about wide characters');
-	}
-	ok(!utf8::is_utf8($forced) && $forced eq $bytes, 'ENV store encodes high utf8 in SV');
-	env_is(foo => $bytes, 'ENV store encodes high utf8 in SV');
+    # warn when downgrading utf8 is not possible
+    $chars = "X-Day \x{1998}";
+    utf8::encode($bytes = $chars);
+    {
+      my $warned = 0;
+      local $SIG{__WARN__} = sub { ++$warned if $_[0] =~ /^Wide character in setenv/; print "# @_" };
+      $forced = $ENV{foo} = $chars;
+      ok($warned == 1, 'ENV store warns about wide characters');
+    }
+    ok(!utf8::is_utf8($forced) && $forced eq $bytes, 'ENV store encodes high utf8 in SV');
+    env_is(foo => $bytes, 'ENV store encodes high utf8 in SV');
 
-	# test local $ENV{foo} on existing foo
-	{
-	  local $ENV{__NoNeSuCh};
-	  { local $TODO = 'exists on %ENV should reflect real env';
-	    ok(!exists $ENV{__NoNeSuCh}, 'not exists $ENV{existing} during local $ENV{existing}'); }
-	  env_is(__NoNeLoCaL => '');
-	}
-	ok(exists $ENV{__NoNeSuCh}, 'exists $ENV{existing} after local $ENV{existing}');
-	env_is(__NoNeSuCh => 'foo');
+    # test local $ENV{foo} on existing foo
+    {
+      local $ENV{__NoNeSuCh};
+      {
+        local $TODO = 'exists on %ENV should reflect real env';
+        ok(!exists $ENV{__NoNeSuCh}, 'not exists $ENV{existing} during local $ENV{existing}');
+      }
+      env_is(__NoNeLoCaL => '', '__NoNeLoCaL');
+    }
+    ok(exists $ENV{__NoNeSuCh}, 'exists $ENV{existing} after local $ENV{existing}');
+    env_is(__NoNeSuCh => 'foo', '__NoNeSuCh');
 
-	# test local $ENV{foo} on new foo
-	{
-	  local $ENV{__NoNeLoCaL} = 'foo';
-	  ok(exists $ENV{__NoNeLoCaL}, 'exists $ENV{new} during local $ENV{new}');
-	  env_is(__NoNeLoCaL => 'foo');
-	}
-	ok(!exists $ENV{__NoNeLoCaL}, 'not exists $ENV{new} after local $ENV{new}');
-	env_is(__NoNeLoCaL => '');
+    # test local $ENV{foo} on new foo
+    {
+      local $ENV{__NoNeLoCaL} = 'foo';
+      ok(exists $ENV{__NoNeLoCaL}, 'exists $ENV{new} during local $ENV{new}');
+      env_is(__NoNeLoCaL => 'foo', '__NoNeLoCaL');
+    }
+    ok(!exists $ENV{__NoNeLoCaL}, 'not exists $ENV{new} after local $ENV{new}');
+    env_is(__NoNeLoCaL => '', '__NoNeLoCaL');
 
     SKIP: {
-	    skip("\$0 check only on Linux and FreeBSD", 2)
-		unless $^O =~ /^(linux|android|freebsd)$/
-		    && open CMDLINE, "/proc/$$/cmdline";
+        skip("\$0 check only on Linux and FreeBSD", 2)
+        unless $^O =~ /^(linux|android|freebsd)$/
+            && open CMDLINE, "/proc/$$/cmdline";
 
-	    chomp(my $line = scalar <CMDLINE>);
-	    my $me = (split /\0/, $line)[0];
-	    is $me, $0, 'altering $0 is effective (testing with /proc/)';
-	    close CMDLINE;
+        chomp(my $line = scalar <CMDLINE>);
+        my $me = (split /\0/, $line)[0];
+        is $me, $0, 'altering $0 is effective (testing with /proc/)';
+        close CMDLINE;
             skip("\$0 check with 'ps' only on Linux (but not Android) and FreeBSD", 1) if $^O eq 'android';
             # perlbug #22811
             my $mydollarzero = sub {
               my($arg) = shift;
               $0 = $arg if defined $arg;
-	      # In FreeBSD the ps -o command= will cause
-	      # an empty header line, grab only the last line.
+              # In FreeBSD the ps -o command= will cause
+              # an empty header line, grab only the last line.
               my $ps = (`ps -o command= -p $$`)[-1];
               return if $?;
               chomp $ps;
@@ -829,19 +848,19 @@ SKIP: {
             };
             my $ps = $mydollarzero->("x");
             ok(!$ps  # we allow that something goes wrong with the ps command
-	       # In Linux 2.4 we would get an exact match ($ps eq 'x') but
-	       # in Linux 2.2 there seems to be something funny going on:
-	       # it seems as if the original length of the argv[] would
-	       # be stored in the proc struct and then used by ps(1),
-	       # no matter what characters we use to pad the argv[].
-	       # (And if we use \0:s, they are shown as spaces.)  Sigh.
+           # In Linux 2.4 we would get an exact match ($ps eq 'x') but
+           # in Linux 2.2 there seems to be something funny going on:
+           # it seems as if the original length of the argv[] would
+           # be stored in the proc struct and then used by ps(1),
+           # no matter what characters we use to pad the argv[].
+           # (And if we use \0:s, they are shown as spaces.)  Sigh.
                || $ps =~ /^x\s*$/
-	       # FreeBSD cannot get rid of both the leading "perl :"
-	       # and the trailing " (perl)": some FreeBSD versions
-	       # can get rid of the first one.
-	       || ($^O eq 'freebsd' && $ps =~ m/^(?:perl: )?x(?: \(perl\))?$/),
-		       'altering $0 is effective (testing with `ps`)');
-	}
+           # FreeBSD cannot get rid of both the leading "perl :"
+           # and the trailing " (perl)": some FreeBSD versions
+           # can get rid of the first one.
+           || ($^O eq 'freebsd' && $ps =~ m/^(?:perl: )?x(?: \(perl\))?$/),
+               'altering $0 is effective (testing with `ps`)');
+    }
 }
 
 # test case-insignificance of %ENV (these tests must be enabled only

--- a/t/op/multideref.t
+++ b/t/op/multideref.t
@@ -15,8 +15,6 @@ BEGIN {
     set_up_inc("../lib");
 }
 
-use warnings;
-
 plan 65;
 
 
@@ -199,10 +197,10 @@ sub defer {}
             my $x = $a[ 'foo' eq $arg ? 1 : 0 ];
             1;
         },
-        "#123609: eval"
+        "#123609 (GH #14419): eval"
     )
         or diag("eval gave: $@");
-    is($warn, "", "#123609: warn");
+    is($warn, "", "#123609 (GH #14419): warn");
 }
 
 # RT #130727
@@ -214,12 +212,12 @@ sub defer {}
     eval { @{local $x[0][0]} = 1; };
     like $@, qr/Can't use an undefined value as an ARRAY reference/,
                     "RT #130727 error";
-    ok !defined $x[0][0],"RT #130727 array not autovivified";
+    ok !defined $x[0][0],"RT #130727 (GH #15864) array not autovivified";
 
     eval { @{1, local $x[0][0]} = 1; };
     like $@, qr/Can't use an undefined value as an ARRAY reference/,
                     "RT #130727 part 2: error";
-    ok !defined $x[0][0],"RT #130727 part 2: array not autovivified";
+    ok !defined $x[0][0],"RT #130727 (GH #15864) part 2: array not autovivified";
 
 }
 
@@ -229,7 +227,7 @@ sub defer {}
     our $rt131627 = 1;
 
     no strict qw(refs vars);
-    is $x[qw(rt131627)->$*], 11, 'RT #131627: $a[qw(var)->$*]';
+    is $x[qw(rt131627)->$*], 11, 'RT #131627 (GH #16029): $a[qw(var)->$*]';
 }
 
 # this used to leak - run the code for ASan to spot any problems
@@ -241,5 +239,9 @@ sub defer {}
     ::pass("S_maybe_multideref() shouldn't leak on croak");
 }
 
-fresh_perl_is('no strict q|refs|; 0for%{scalar local$0[0]}', '', {},
-              "RT #134045 assertion on the OP_SCALAR");
+fresh_perl_is(
+    'no strict q|refs|; no warnings q|uninitialized|; 0for%{scalar local$0[0]}',
+    '',
+    {},
+    "RT #134045 (GH #16969) assertion on the OP_SCALAR"
+);

--- a/t/op/my.t
+++ b/t/op/my.t
@@ -72,8 +72,8 @@ is($main::y, "ok 20\n", 'this one too');
 
 my $i = "outer";
 
-if (my $i = "inner") {
-    is( $i, 'inner', 'my variable inside conditional propagates inside block');
+if (my $i or 1) {
+    is( $i, undef, 'my variable inside conditional propagates inside block');
 }
 
 if ((my $i = 1) == 0) {

--- a/t/op/numconvert.t
+++ b/t/op/numconvert.t
@@ -155,35 +155,36 @@ for my $num_chain (1..$max_chain) {
 	    #next if $num_chain > 1
 	    #  and "$tmp" ne "$tmp1"; # Already the coercion gives problems...
 
-	    for my $curop (@{$curops[$short]}) {
-	      if ($curop < 5) {
-		if ($curop < 3) {
-		  if ($curop == 0) {
-		    --$inpt;	# - 0
-		  } elsif ($curop == 1) {
-		    ++$inpt;	# + 1
-		  } else {
-		    $inpt = $max_uv & $inpt; # U 2
-		  }
-		} elsif ($curop == 3) {
-		  use integer; $inpt += $zero;
-		} else {
-		  $inpt += $zero; # N 4
-		}
-	      } elsif ($curop < 8) {
-		if ($curop == 5) {
-		  $inpt = "$inpt"; # P 5
-		} elsif ($curop == 6) {
-		  my $dummy = $max_uv & $inpt; # u 6
-		} else {
-		  use integer; my $dummy = $inpt + $zero;
-		}
-	      } elsif ($curop == 8) {
-		my $dummy = $inpt + $zero;	# n 8
-	      } else {
-		my $dummy = $inpt . "";	# p 9
-	      }
-	    }
+      no warnings 'imprecision';
+      for my $curop (@{$curops[$short]}) {
+        if ($curop < 5) {
+          if ($curop < 3) {
+            if ($curop == 0) {
+              --$inpt;  # - 0
+            } elsif ($curop == 1) {
+              ++$inpt;  # + 1
+            } else {
+              $inpt = $max_uv & $inpt; # U 2
+            }
+          } elsif ($curop == 3) {
+            use integer; $inpt += $zero;
+          } else {
+            $inpt += $zero; # N 4
+          }
+        } elsif ($curop < 8) {
+          if ($curop == 5) {
+            $inpt = "$inpt"; # P 5
+          } elsif ($curop == 6) {
+            my $dummy = $max_uv & $inpt; # u 6
+          } else {
+            use integer; my $dummy = $inpt + $zero;
+          }
+        } elsif ($curop == 8) {
+          my $dummy = $inpt + $zero;  # n 8
+        } else {
+          my $dummy = $inpt . "";  # p 9
+        }
+      }
 
 	    if ($last == 2) {
 	      $inpt = sprintf "%u", $inpt; # U 2

--- a/t/op/override.t
+++ b/t/op/override.t
@@ -53,6 +53,7 @@ is( $r, join($dirsep, "Foo", "Bar.pm") );
 
 {
     my @r;
+    no warnings 'redefine';
     local *CORE::GLOBAL::require = sub { push @r, shift; 1; };
     eval "use 5.006";
     like( " @r ", qr " 5\.006 " );
@@ -133,6 +134,7 @@ BEGIN { *OverridenPop::pop = sub { ::is( $_[0][0], "ok" ) }; }
 
 {
     eval {
+        no warnings 'redefine';
         local *CORE::GLOBAL::require = sub {
             CORE::require($_[0]);
         };
@@ -145,8 +147,11 @@ BEGIN { *OverridenPop::pop = sub { ::is( $_[0][0], "ok" ) }; }
 # Constant inlining should not countermand "use subs" overrides
 BEGIN { package other; *::caller = \&::caller }
 sub caller() { 42 }
-caller; # inline the constant
-is caller, 42, 'constant inlining does not undo "use subs" on keywords';
+{
+    no warnings 'void';
+    caller; # inline the constant
+    is caller, 42, 'constant inlining does not undo "use subs" on keywords';
+}
 
 is runperl(prog => 'sub CORE::GLOBAL::do; do file; print qq-ok\n-'),
   "ok\n",

--- a/t/op/pack.t
+++ b/t/op/pack.t
@@ -2049,8 +2049,9 @@ SKIP:
     # [perl #129149] the code below would write one past the end of the output
     # buffer, only detected by ASAN, not by valgrind
     $Config{ivsize} >= 8
-      or skip "[perl #129149] need 64-bit for this test", 1;
+      or skip "[perl #129149] [gh #15572] need 64-bit for this test", 1;
     fresh_perl_is(<<'EOS', "ok\n", { stderr => 1 }, "pack W overflow");
+no warnings 'non_unicode'; no warnings 'portable';
 print pack("ucW", "0000", 0, 140737488355327) eq "\$,#`P,```\n\0\x{7fffffffffff}"
  ? "ok\n" : "not ok\n";
 EOS
@@ -2060,7 +2061,7 @@ SKIP:
 {
   # [perl #131844] pointer addition overflow
     $Config{ptrsize} == 4
-      or skip "[perl #131844] need 32-bit build for this test", 4;
+      or skip "[perl #131844] [gh #16098] need 32-bit build for this test", 4;
     # prevent ASAN just crashing on the allocation failure
     local $ENV{ASAN_OPTIONS} = $ENV{ASAN_OPTIONS};
     $ENV{ASAN_OPTIONS} .= ",allocator_may_return_null=1";
@@ -2081,6 +2082,10 @@ SKIP:
 {
     # [perl #132655] heap-buffer-overflow READ of size 11
     # only expect failure under ASAN (and maybe valgrind)
-    fresh_perl_is('0.0 + unpack("u", "ab")', "", { stderr => 1 },
-                  "ensure unpack u of invalid data nul terminates result");
+    fresh_perl_is(
+        'no warnings q|void|; no warnings q|numeric|; 0.0 + unpack("u", "ab")',
+        "",
+        { stderr => 1 },
+        "ensure unpack u of invalid data nul terminates result"
+    );
 }

--- a/t/op/quotemeta.t
+++ b/t/op/quotemeta.t
@@ -10,7 +10,7 @@ BEGIN {
 
 plan tests => 60;
 
-if ($Config{ebcdic} eq 'define') {
+if (($Config{ebcdic} || '') eq 'define') {
     $_ = join "", map chr($_), 129..233;
 
     # 105 characters - 52 letters = 53 backslashes
@@ -42,8 +42,11 @@ is("\u\LpE\Q#X#\ER\EL", "Pe\\#x\\#rL", '\u\LpE\Q#X#\ER\EL');
 is("\l\UPe\Q!x!\Er\El", "pE\\!X\\!Rl", '\l\UPe\Q!x!\Er\El');
 is("\Q\u\LpE.X.R\EL\E.", "Pe\\.x\\.rL.", '\Q\u\LpE.X.R\EL\E.');
 is("\Q\l\UPe*x*r\El\E*", "pE\\*X\\*Rl*", '\Q\l\UPe*x*r\El\E*');
-is("\U\lPerl\E\E\E\E", "pERL", '\U\lPerl\E\E\E\E');
-is("\l\UPerl\E\E\E\E", "pERL", '\l\UPerl\E\E\E\E');
+{
+    no warnings 'misc';
+    is("\U\lPerl\E\E\E\E", "pERL", '\U\lPerl\E\E\E\E');
+    is("\l\UPerl\E\E\E\E", "pERL", '\l\UPerl\E\E\E\E');
+}
 
 is(quotemeta("\x{263a}"), "\\\x{263a}", "quotemeta Unicode quoted");
 is(length(quotemeta("\x{263a}")), 2, "quotemeta Unicode quoted length");
@@ -60,7 +63,7 @@ utf8::upgrade($char);
 is(quotemeta($char), "$char", "quotemeta '$char' in UTF-8");
 is(length(quotemeta($char)), 1, "quotemeta '$char'  in UTF-8 length");
 
-my $char = "\N{U+D7}";
+$char = "\N{U+D7}";
 utf8::upgrade($char);
 is(quotemeta($char), "\\$char", "quotemeta '\\N{U+D7}' in UTF-8");
 is(length(quotemeta($char)), 2, "quotemeta '\\N{U+D7}'  in UTF-8 length");
@@ -93,7 +96,7 @@ is(length(quotemeta($char)), 1, "quotemeta '\\N{U+DF}'  in UTF-8 length");
     is(quotemeta($char), "$char", "quotemeta '$char' locale");
     is(length(quotemeta($char)), 1, "quotemeta '$char' locale");
 
-    my $char = "\x{BF}";
+    $char = "\x{BF}";
     is(quotemeta($char), "\\$char", "quotemeta '\\x{BF}' locale");
     is(length(quotemeta($char)), 2, "quotemeta '\\x{BF}' locale length");
 
@@ -123,7 +126,7 @@ is(length(quotemeta($char)), 1, "quotemeta '\\N{U+DF}'  in UTF-8 length");
     is(quotemeta($char), "$char", "quotemeta '$char' locale in UTF-8");
     is(length(quotemeta($char)), 1, "quotemeta '$char' locale in UTF-8 length");
 
-    my $char = "\N{U+D7}";
+    $char = "\N{U+D7}";
     utf8::upgrade($char);
     is(quotemeta($char), "\\$char", "quotemeta '\\N{U+D7}' locale in UTF-8");
     is(length(quotemeta($char)), 2, "quotemeta '\\N{U+D7}' locale in UTF-8 length");

--- a/t/op/readdir.t
+++ b/t/op/readdir.t
@@ -62,6 +62,7 @@ isnt("$fh", "$fh{abc}");
 fresh_perl_like(<<'EOP', qr/^no crash/, {}, 'GH #9813');
   eval {
     my $x = ".";
+    no warnings 'io';
     my @files = readdir($x);
   };
   print "no crash";

--- a/t/op/recurse.t
+++ b/t/op/recurse.t
@@ -104,7 +104,7 @@ is(takeuchi($x, $y, $z), $z + 1, "takeuchi($x, $y, $z) == $z + 1");
 }
 
 {
-    local $^W = 0; # We do not need recursion depth warning.
+    no warnings 'recursion';
 
     sub sillysum {
 	return $_[0] + ($_[0] > 0 ? sillysum($_[0] - 1) : 0);

--- a/t/op/repeat.t
+++ b/t/op/repeat.t
@@ -15,10 +15,13 @@ is('-' x 3.1, '---',    'compile time 3.1');
 is('-' x 3.9, '---',    'compile time 3.9');
 is('-' x 1, '-',        '  x 1');
 is('-' x 0, '',         '  x 0');
-is('-' x -1, '',        '  x -1');
-is('-' x undef, '',     '  x undef');
-is('-' x "foo", '',     '  x "foo"');
-is('-' x "3rd", '---',  '  x "3rd"');
+{ no warnings 'numeric'; is('-' x -1, '',        '  x -1'); }
+{ no warnings 'uninitialized'; is('-' x undef, '',     '  x undef'); }
+{
+    no warnings 'numeric';
+    is('-' x "foo", '',     '  x "foo"');
+    is('-' x "3rd", '---',  '  x "3rd"');
+}
 
 is('ab' x 3, 'ababab',  '  more than one char');
 
@@ -30,17 +33,20 @@ is($alpha x 3.1, '---',     '  x 3.1');
 is($alpha x 3.9, '---',     '  x 3.9');
 is($alpha x 1, '-',         '  x 1');
 is($alpha x 0, '',          '  x 0');
-is($alpha x -3, '',         '  x -3');
-is($alpha x undef, '',      '  x undef');
-is($alpha x "foo", '',      '  x "foo"');
-is($alpha x "3rd", '---',   '  x "3rd"');
+{ no warnings 'numeric'; is($alpha x -3, '',         '  x -3'); }
+{ no warnings 'uninitialized'; is($alpha x undef, '',      '  x undef'); }
+{
+    no warnings 'numeric';
+    is($alpha x "foo", '',      '  x "foo"');
+    is($alpha x "3rd", '---',   '  x "3rd"');
+}
 
 $alpha = 'ab';
 is($alpha x 3, 'ababab',    '  more than one char');
 $alpha = 'ab';
 is($alpha x 0, '',          '  more than one char');
 $alpha = 'ab';
-is($alpha x -12, '',        '  more than one char');
+{ no warnings 'numeric'; is($alpha x -12, '',        '  more than one char'); }
 
 $alpha = 'xyz';
 $alpha x= 2;
@@ -61,8 +67,11 @@ is(join(':', (9) x 4),      '9:9:9:9',              '(X) x Y');
 is(join(':', (9,9) x 4),    '9:9:9:9:9:9:9:9',      '(X,X) x Y');
 is(join('', (split(//,"123")) x 2), '123123',       'split and x');
 
-is(join('', @x x -12),      '',                     '@x x -12');
-is(join('', (@x) x -14),    '',                     '(@x) x -14');
+{
+    no warnings 'numeric';
+    is(join('', @x x -12),      '',                     '@x x -12');
+    is(join('', (@x) x -14),    '',                     '(@x) x -14');
+}
 
 my $beta;
 ($alpha, (undef)x5, $beta) = 1..10;
@@ -144,11 +153,11 @@ is(77, scalar ((1,7)x2),    'stack truncation');
 
 # ( )x in void context should not read preceding stack items
 package Tiecount {
-    sub TIESCALAR { bless[]} sub FETCH { our $Tiecount++; study; 3 }
+    sub TIESCALAR { bless[]} sub FETCH { no warnings 'uninitialized'; our $Tiecount++; study; 3 }
 }
 sub nil {}
 tie my $t, "Tiecount";
-{ push my @temp, $t, scalar((nil) x 3, 1) }
+{ no warnings 'void'; no warnings 'uninitialized'; push my @temp, $t, scalar((nil) x 3, 1) }
 is($Tiecount::Tiecount, 1,
    '(...)x... in void context in list (via scalar comma)');
 
@@ -197,7 +206,7 @@ is($@, "", "RT #130247");
 
 # yes, the newlines matter
 fresh_perl_is(<<'PERL', "", { stderr => 1 }, "(perl #133778) MARK mishandling");
-map{s[][];eval;0}<DATA>__END__
+no warnings q|uninitialized|;map{s[][];eval;0}<DATA>__END__
 
 
 

--- a/t/op/runlevel.t
+++ b/t/op/runlevel.t
@@ -22,6 +22,7 @@ my @a = (1, 2, 3);
   @a = sort { last ; } @a;
 }
 EXPECT
+Exiting pseudo-block via last at - line 3.
 Can't "last" outside a loop block at - line 3.
 ########
 package TEST;
@@ -74,6 +75,7 @@ sub TIEHANDLE {
 }
 sub PRINT {
 print STDERR "PRINT CALLED\n";
+no warnings 'void';
 (split(/./, 'x'x10000))[0];
 eval('die("test\n")');
 }
@@ -143,6 +145,7 @@ Can't "goto" out of a pseudo block at - line 2.
 ########
 my %seen = ();
 sub sortfn {
+  no warnings 'void';
   (split(/./, 'x'x10000))[0];
   my (@y) = ( 4, 6, 5);
   @y = sort { $a <=> $b } @y;
@@ -169,6 +172,7 @@ foo:
   @a = sort { last foo; } @a;
 }
 EXPECT
+Exiting pseudo-block via last at - line 4.
 Label not found for "last foo" at - line 4.
 ########
 package TEST;
@@ -192,6 +196,7 @@ tie $bar, 'TEST';
 }
 print "OK\n";
 EXPECT
+Exiting subroutine via next at - line 8.
 Can't "next" outside a loop block at - line 8.
 ########
 package TEST;
@@ -252,6 +257,7 @@ my $bar = '';
 tie $bar, 'TEST';
 }
 EXPECT
+Exiting subroutine via next at - line 4.
 Can't "next" outside a loop block at - line 4.
 ########
 my @a = (1, 2, 3);
@@ -344,6 +350,7 @@ tie *STDERR, '';
 { map ++$_, 1 }
 
 EXPECT
+Exiting subroutine via next at - line 2.
 Can't "next" outside a loop block at - line 2.
 ########
 sub TIEHANDLE { bless {} }
@@ -357,10 +364,12 @@ EXPECT
 ########
 sub TIEHANDLE { bless {} }
 sub PRINT { 
+    no warnings 'void';
     (split(/./, 'x'x10000))[0];
     eval('die("test\n")');
     warn "[TIE] $_[1]";
 }
+no warnings 'once';
 open OLDERR, '>&STDERR';
 tie *STDERR, '';
 
@@ -368,4 +377,4 @@ use warnings FATAL => qw(uninitialized);
 print undef;
 
 EXPECT
-[TIE] Use of uninitialized value in print at - line 11.
+[TIE] Use of uninitialized value in print at - line 13.


### PR DESCRIPTION
Another batch of updates to files in `t/op/*.t` to accomodate them to warnings-on-by-default (https://github.com/atoomic/perl/issues/309).  Roughly speaking, this covers files beginning with `m` through `r`.  Please review.

Thank you very much.
Jim Keenan