### PR TITLE
Lib warnings 20201216

### DIFF
--- a/lib/English.t
+++ b/lib/English.t
@@ -26,9 +26,12 @@ foo(1);
 
 "abc" =~ /b/;
 
-ok( !$PREMATCH, '$PREMATCH undefined' );
-ok( !$MATCH, '$MATCH undefined' );
-ok( !$POSTMATCH, '$POSTMATCH undefined' );
+{
+    no warnings 'once';
+    ok( !$PREMATCH, '$PREMATCH undefined' );
+    ok( !$MATCH, '$MATCH undefined' );
+    ok( !$POSTMATCH, '$POSTMATCH undefined' );
+}
 
 $OFS = " ";
 $ORS = "\n";
@@ -69,7 +72,10 @@ is( $ACCUMULATOR, $^A, '$ACCUMULATOR' );
 
 undef $OUTPUT_FIELD_SEPARATOR;
 
-if ($threads) { $" = "\n" } else { $LIST_SEPARATOR = "\n" };
+{
+    no warnings 'once';
+    if ($threads) { $" = "\n" } else { $LIST_SEPARATOR = "\n" };
+}
 my @foo = (8, 9);
 @foo = split(/\n/, "@foo");
 is( $foo[0], 8, '$"' );
@@ -157,9 +163,12 @@ use English qw( -no_match_vars ) ;
 
 "abc" =~ /b/;
 
-main::ok( !$PREMATCH, '$PREMATCH disabled' );
-main::ok( !$MATCH, '$MATCH disabled' );
-main::ok( !$POSTMATCH, '$POSTMATCH disabled' );
+{
+    no warnings 'once';
+    main::ok( !$PREMATCH, '$PREMATCH disabled' );
+    main::ok( !$MATCH, '$MATCH disabled' );
+    main::ok( !$POSTMATCH, '$POSTMATCH disabled' );
+}
 
 
 # Check that both variables change when localized.

--- a/lib/File/Compare.t
+++ b/lib/File/Compare.t
@@ -105,7 +105,8 @@ SKIP: {
     TODO: {
         my $why = "spaces after filename silently truncated";
         my $how_many = 1;
-        my $condition = ($^O eq "cygwin") or ($^O eq "vos");
+        my $condition;
+        { no warnings 'void'; $condition = ($^O eq "cygwin") or ($^O eq "vos"); }
         todo_skip $why, $how_many if $condition;
         is($donetests[2], 0, "file/fileCR [$donetests[2]]");
     }

--- a/lib/Symbol.t
+++ b/lib/Symbol.t
@@ -87,6 +87,7 @@ use Symbol qw(qualify qualify_to_ref);  # must import into this package too
 
 # tests for delete_package
 package main;
+no warnings 'once';
 $Transient::variable = 42;
 ok( exists $::{'Transient::'}, 'transient stash exists' );
 ok( defined $Transient::{variable}, 'transient variable in stash' );

--- a/lib/Tie/Handle/stdhandle.t
+++ b/lib/Tie/Handle/stdhandle.t
@@ -9,7 +9,7 @@ use Test::More tests => 29;
 
 use_ok('Tie::StdHandle');
 
-tie *tst, 'Tie::StdHandle';
+{ no warnings 'once'; tie *tst, 'Tie::StdHandle'; }
 
 our $f = 'tst';
 

--- a/lib/bytes.t
+++ b/lib/bytes.t
@@ -14,8 +14,11 @@ is(length($a), 1,  "length sanity check");
 is(substr($a, 0, 1), "\x{100}",  "substr sanity check");
 is(index($a, "\x{100}"),  0, "index sanity check");
 is(rindex($a, "\x{100}"), 0, "rindex sanity check");
-is(bytes::length($a), 2,  "bytes::length sanity check");
-is(bytes::chr(0x100), chr(0),  "bytes::chr sanity check");
+{
+    no warnings 'prototype';
+    is(bytes::length($a), 2,  "bytes::length sanity check");
+    is(bytes::chr(0x100), chr(0),  "bytes::chr sanity check");
+}
 
 {
     use bytes;

--- a/lib/perl5db.t
+++ b/lib/perl5db.t
@@ -6,7 +6,6 @@ BEGIN {
     require './test.pl';
 }
 
-use warnings;
 use Config;
 
 delete $ENV{PERLDB_OPTS};

--- a/lib/perl5db/t/rt-61222
+++ b/lib/perl5db/t/rt-61222
@@ -4,7 +4,7 @@
 #
 
 package Pie;
-
+no warnings 'illegalproto';
 sub INCORRECT (DB);
 
 1;

--- a/lib/perlbug.t
+++ b/lib/perlbug.t
@@ -137,7 +137,7 @@ $result = runperl( progfile => $extracted_program,
                                 '-e', 'file',
                                 '-F', $testreport] );
 like($result, qr/Report saved/, 'fake bug report saved');
-my $contents = _slurp($testreport);
+$contents = _slurp($testreport);
 unlink $testreport, $body, $attachment;
 like($contents, qr/Subject: testing perlbug/,
      'Subject included in fake bug report');

--- a/lib/strict.t
+++ b/lib/strict.t
@@ -7,16 +7,20 @@ our $local_tests = 6;
 require "../t/lib/common.pl";
 
 eval qq(use strict 'garbage');
-like($@, qr/^Unknown 'strict' tag\(s\) 'garbage'/);
+like($@, qr/^Unknown 'strict' tag\(s\) 'garbage'/,
+    "Caught exception for unknown stricture with 'use'");
 
 eval qq(no strict 'garbage');
-like($@, qr/^Unknown 'strict' tag\(s\) 'garbage'/);
+like($@, qr/^Unknown 'strict' tag\(s\) 'garbage'/,
+    "Caught exception for unknown stricture with 'no'");
 
 eval qq(use strict qw(foo bar));
-like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
+like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/,
+    "Caught exception for unknown strictures with 'use'");
 
 eval qq(no strict qw(foo bar));
-like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/);
+like($@, qr/^Unknown 'strict' tag\(s\) 'foo bar'/,
+    "Caught exception for unknown strictures with 'no'");
 
 eval 'use v5.12; use v5.10; ${"c"}';
 is($@, '', 'use v5.10 disables implicit strict refs');

--- a/lib/vmsish.t
+++ b/lib/vmsish.t
@@ -129,7 +129,7 @@ is($?,0,"outer lex scope of vmsish [POSIX status]");
     my $oldtz = $ENV{'SYS$TIMEZONE_DIFFERENTIAL'};
     $ENV{'SYS$TIMEZONE_DIFFERENTIAL'} = 3600;
     eval "END { \$ENV{'SYS\$TIMEZONE_DIFFERENTIAL'} = $oldtz; }";
-    gmtime(0); # Force reset of tz offset
+    no warnings 'void'; gmtime(0); # Force reset of tz offset
   }
 
   # Unless we are prepared to parse the timezone rules here and figure out
@@ -140,7 +140,7 @@ is($?,0,"outer lex scope of vmsish [POSIX status]");
   my $file = 'sys$scratch:vmsish_t_flirble.tmp';
   open TMP, '>', $file or die "Couldn't open file $file";
   close TMP;
-  END { 1 while unlink $file; }
+  END { no warnings 'uninitialized'; 1 while unlink $file; }
 
   {
      use_ok('vmsish', 'time');

--- a/t/lib/feature/indirect
+++ b/t/lib/feature/indirect
@@ -11,21 +11,27 @@ my $foox = "foox";
 print STDERR "Hello\n";
 printf STDERR "Test%s\n", "x";
 say STDERR "Hello";
-exec $foox "foo", "bar";
-system $foox "foo", "bar";
+{
+    no warnings 'exec';
+    exec $foox "foo", "bar";
+    system $foox "foo", "bar";
+}
 my $x = new Foo;
 no feature "indirect";
 print STDERR "Hello\n";
 printf STDERR "Test%s\n", "x";
 say STDERR "Hello";
-exec $foox "foo", "bar";
-system $foox "foo", "bar";
+{
+    no warnings 'exec';
+    exec $foox "foo", "bar";
+    system $foox "foo", "bar";
+}
 my $y = new Foo;
 EXPECT
 OPTIONS fatal
-Bareword found where operator expected at - line 19, near "new Foo"
+Bareword found where operator expected at - line 25, near "new Foo"
 	(Do you need to predeclare new?)
-syntax error at - line 19, near "new Foo"
+syntax error at - line 25, near "new Foo"
 Execution of - aborted due to compilation errors.
 ########
 # NAME METHOD BLOCK

--- a/t/lib/strict/refs
+++ b/t/lib/strict/refs
@@ -7,39 +7,39 @@ no strict;
 my $fred ;
 $b = "fred" ;
 $a = $$b ;
-$c = ${"def"} ;
-$c = @{"def"} ;
-$c = %{"def"} ;
-$c = *{"def"} ;
-$c = \&{"def"} ;
-$c = def->[0];
-$c = def->{xyz};
+$c = ${"Def"} ;
+$c = @{"Def"} ;
+$c = %{"Def"} ;
+$c = *{"Def"} ;
+$c = \&{"Def"} ;
+$c = Def->[0];
+$c = Def->{xyz};
 EXPECT
 
 ########
 
 # strict refs - error
-my $str="A::Really::Big::Package::Name::To::Use"; 
+no warnings 'void'; my $str="A::Really::Big::Package::Name::To::Use"; 
 $str->{foo}= 1;
 EXPECT
 Can't use string ("A::Really::Big::Package::Name::T"...) as a HASH ref while "strict refs" in use at - line 4.
 ########
 
 # strict refs - error
-"A::Really::Big::Package::Name::To::Use" =~ /(.*)/; 
+no warnings 'void'; "A::Really::Big::Package::Name::To::Use" =~ /(.*)/; 
 ${$1};
 EXPECT
 Can't use string ("A::Really::Big::Package::Name::T"...) as a SCALAR ref while "strict refs" in use at - line 4.
 ########
 
 # strict refs - error
-*{"A::Really::Big::Package::Name::To::Use"; }
+no warnings 'void'; *{"A::Really::Big::Package::Name::To::Use"; }
 EXPECT
 Can't use string ("A::Really::Big::Package::Name::T"...) as a symbol ref while "strict refs" in use at - line 3.
 ########
 
 # strict refs - error
-"A::Really::Big::Package::Name::To::Use" =~ /(.*)/;
+no warnings 'void'; "A::Really::Big::Package::Name::To::Use" =~ /(.*)/;
 *{$1}
 EXPECT
 Can't use string ("A::Really::Big::Package::Name::T"...) as a symbol ref while "strict refs" in use at - line 4.
@@ -219,7 +219,7 @@ use strict 'refs' ;
 my $alpha = ${"Fred"} ;
 1;
 --FILE-- 
-${"Fred"} ;
+no warnings 'void'; ${"Fred"} ;
 require "./abc";
 EXPECT
 Can't use string ("Fred") as a SCALAR ref while "strict refs" in use at - line 1.
@@ -324,20 +324,20 @@ Can't use string ("Fred") as a SCALAR ref while "strict refs" in use at - line 8
 ########
 # [perl #26910] hints not propagated into (?{...})
 use strict 'refs';
-/(?{${"foo"}++})/;
+no warnings 'uninitialized'; /(?{${"foo"}++})/;
 EXPECT
 Can't use string ("foo") as a SCALAR ref while "strict refs" in use at - line 3.
 ########
 # [perl #37886] strict 'refs' doesn't apply inside defined
 use strict 'refs';
 my $x = "foo";
-defined $$x;
+no warnings 'void'; defined $$x;
 EXPECT
 Can't use string ("foo") as a SCALAR ref while "strict refs" in use at - line 4.
 ########
 # [perl #74168] Assertion failed: (SvTYPE(_svcur) >= SVt_PV), function Perl_softref2xv, file pp.c, line 240.
 use strict 'refs';
-my $o = 1 ; $o->{1} ;
+my $o = 1 ; no warnings 'void'; $o->{1} ;
 EXPECT
 Can't use string ("1") as a HASH ref while "strict refs" in use at - line 3.
 ########

--- a/t/lib/strict/subs
+++ b/t/lib/strict/subs
@@ -4,24 +4,24 @@ __END__
 
 # no strict, should build & run ok.
 no strict;
-Fred ;
+{ no warnings 'void'; Fred; }
 my $fred ;
 $beta = "fred" ;
-$alpha = $$beta ;
+{ no warnings 'once'; $alpha = $$beta; }
 EXPECT
 
 ########
 
 # no strict subs, bareword ok.
 no strict 'subs' ;
-Fred ;
+no warnings 'void'; Fred ;
 EXPECT
 
 ########
 
 use strict ;
 no strict 'subs' ;
-Fred ;
+no warnings 'void'; Fred ;
 EXPECT
 
 ########
@@ -274,7 +274,7 @@ no strict ;
 eval '
     Fred ;
 '; print STDERR $@ ;
-Fred ;
+no warnings 'void'; Fred ;
 EXPECT
 
 ########
@@ -396,13 +396,13 @@ Execution of - aborted due to compilation errors.
 ########
 #  [perl #27628] strict 'subs' didn't warn on bareword array index
 use strict 'subs';
-my @a; my $x=$a[FOO];
+my @a; no warnings 'numeric'; my $x=$a[FOO];
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 3.
 Execution of - aborted due to compilation errors.
 ########
 use strict 'subs';
-my @a;my $x=$a[FOO];
+my @a; no warnings 'numeric'; my $x=$a[FOO];
 EXPECT
 Bareword "FOO" not allowed while "strict subs" in use at - line 2.
 Execution of - aborted due to compilation errors.
@@ -430,7 +430,7 @@ sub _rankCompare2 { }
 EXPECT
 
 ########
-use strict;
+use strict; no warnings 'unopened';
 readline(FOO);
 EXPECT
 

--- a/t/lib/strict/vars
+++ b/t/lib/strict/vars
@@ -4,23 +4,23 @@ __END__
 
 # no strict, should build & run ok.
 no strict ;
-Fred ;
+{ no warnings 'void';  Fred; }
 my $fred ;
 $beta = "fred" ;
-$alpha = $$beta ;
+{ no warnings 'once'; $alpha = $$beta ; }
 EXPECT
 
 ########
 
 no strict 'vars' ;
-$fred ;
+no warnings 'void'; no warnings 'once'; $fred ;
 EXPECT
 
 ########
 
 use strict ;
 no strict 'vars' ;
-$fred ;
+no warnings 'void'; no warnings 'once'; $fred ;
 EXPECT
 
 ########
@@ -156,7 +156,7 @@ $jòè = 1 ;
 no strict 'vars' ;
 use utf8;
 use open qw( :utf8 :std );
-$jòè = 1 ;
+no warnings 'once'; $jòè = 1 ;
 require "./abc";
 EXPECT
 Variable "$jòè" is not imported at ./abc line 4.
@@ -394,7 +394,7 @@ sub foo {
     our $fred;
     $fred;
 }
-$fred ;
+no warnings 'void'; $fred ;
 EXPECT
 
 ########
@@ -542,7 +542,7 @@ Execution of - aborted due to compilation errors.
 ########
 # [perl #73712] [gh #10245] 'Variable is not imported' should be suppressible
 no strict 'vars';
-$dweck;
+{ no warnings 'void'; no warnings 'once'; $dweck; }
 no warnings;
 eval q/$dweck/;
 EXPECT

--- a/utils/h2ph.PL
+++ b/utils/h2ph.PL
@@ -283,7 +283,7 @@ while (defined (my $file = next_file())) {
 	    foreach my $enum (@enum_subs) {
 		my ($enum_name, $enum_value) = $enum =~ /^([a-zA-Z_]\w*)(=.+)?$/;
 		$enum_name or next;
-		$enum_value =~ s/^=//;
+		{ no warnings 'uninitialized'; $enum_value =~ s/^=//; }
 		$enum_val = (length($enum_value) ? $enum_value : $enum_val + 1);
 		if ($opt_h) {
 		    print OUT ($t,
@@ -641,6 +641,7 @@ sub next_line
             }
         }
 
+        no warnings 'uninitialized';
         last READ if $out =~ /\S/;
     }
 


### PR DESCRIPTION
This pull request should get all tests under `lib/` to pass and run warnings-free **except** `lib/B/Deparse-core.t` and `lib/warnings.t`.  Hence, this p.r. **partially** satisifies the ask in https://github.com/atoomic/perl/issues/306.  Please review.