### PR TITLE
t/run/switches.t: Enable compile under miniperl

### DIFF
--- a/t/run/switches.t
+++ b/t/run/switches.t
@@ -115,7 +115,7 @@ SKIP: {
 
     local $ENV{'LC_ALL'} = 'C'; # Keep the test simple: expect English
     local $ENV{LANGUAGE} = 'C';
-    setlocale(LC_ALL, "C");
+    setlocale('LC_ALL', "C");
 
     # Win32 won't let us open the directory, so we never get to die with
     # EISDIR, which happens after open.


### PR DESCRIPTION
When run as part of 'make minitest', this file was failing with a
bareword not permitted under strict error.

For: https://github.com/atoomic/perl/issues/349