### PR TITLE
t/op/coreamp.t: Better spelling of function call

### DIFF
--- a/t/op/coreamp.t
+++ b/t/op/coreamp.t
@@ -1168,14 +1168,14 @@ like $@, qr'^Undefined format "STDOUT" called',
    "&write without arguments can handle the null";
 
 # This is just a check to make sure we have tested everything.  If we
-# haven’t, then either the sub needs to be tested or the list in
+# haven't, then either the sub needs to be tested or the list in
 # gv.c is wrong.
 {
   last if is_miniperl;
   require File::Spec::Functions;
   my $keywords_file =
    File::Spec::Functions::catfile(
-      File::Spec::Functions::updir,'regen','keywords.pl'
+      File::Spec::Functions::updir(),'regen','keywords.pl'
    );
   my %nottest_words = map { $_ => 1 } qw(
     AUTOLOAD BEGIN CHECK CORE DESTROY END INIT UNITCHECK


### PR DESCRIPTION
When run under miniperl (and strict-by-default), the invocation of
File::Spec::Functions::updir without parens was being read as a
bareword, generating an exception.

For: https://github.com/atoomic/perl/issues/351