### PR TITLE
Gha 18245 ext posix t posix 20201223

### DIFF
--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -118,8 +118,9 @@ SKIP: {
     }
     sleep 1;
 
-    $todo = 1 if ($^O eq 'freebsd' && $Config{osvers} < 8)
-              || ($^O eq 'darwin' && $Config{osvers} < '6.6');
+    my ($major, $minor) = $Config{osvers} =~ / (\d+) \. (\d+) .* /x;
+    $todo = 1 if ($^O eq 'freebsd' && $major < 8)
+              || ($^O eq 'darwin' && "${major}.${minor}" < '6.6');
     printf "%s 11 - masked SIGINT received %s\n",
         $sigint_called ? "ok" : "not ok",
         $todo ? $why_todo : '';

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -356,7 +356,12 @@ is ($result, undef, "fgets should fail");
 like ($@, qr/^Unimplemented: POSIX::fgets\(\): Use method IO::Handle::gets\(\) instead/,
       "check its redef message");
 
-eval { use strict; no warnings 'uninitialized'; POSIX->import("S_ISBLK"); my $x = S_ISBLK };
+eval {
+    use strict;
+    no warnings 'uninitialized'; # S_ISBLK normally has an arg
+    POSIX->import("S_ISBLK");
+    my $x = S_ISBLK
+};
 unlike( $@, qr/Can't use string .* as a symbol ref/, "Can import autoloaded constants" );
 
 SKIP: {

--- a/ext/POSIX/t/posix.t
+++ b/ext/POSIX/t/posix.t
@@ -365,7 +365,7 @@ eval {
 unlike( $@, qr/Can't use string .* as a symbol ref/, "Can import autoloaded constants" );
 
 SKIP: {
-    skip("locales not available", 26) unless locales_enabled(qw(NUMERIC MONETARY));
+    skip("locales not available", 26) unless locales_enabled([ qw(NUMERIC MONETARY) ]);
     skip("localeconv() not available", 26) unless $Config{d_locconv};
     my $conv = localeconv;
     is(ref $conv, 'HASH', 'localeconv returns a hash reference');

--- a/ext/VMS-DCLsym/t/vms_dclsym.t
+++ b/ext/VMS-DCLsym/t/vms_dclsym.t
@@ -1,17 +1,18 @@
 print "1..30\n";
 
-require VMS::DCLsym or die "not ok 1\n";
+require 'VMS::DCLsym' or die "not ok 1\n";
 print "ok 1\n";
 
-tie %syms, VMS::DCLsym or die "not ok 2\n";
+tie my %syms, 'VMS::DCLsym' or die "not ok 2\n";
 print "ok 2\n";
 
-$name = 'FOO_'.time();
+my $name = 'FOO_'.time();
 $syms{$name} = 'Perl_test';
 print +($! ? "#(\$! = $!)\nnot " : ''),"ok 3\n";
 
 print +($syms{$name} eq 'Perl_test' ? '' : 'not '),"ok 4\n";
 
+my ($val, $sym);
 ($val) = `Show Symbol $name` =~ /(\w+)"$/;
 print +($val eq 'Perl_test' ? '' : 'not '),"ok 5\n";
 
@@ -25,7 +26,7 @@ print +($! ? "#(\$! = $!)\nnot " : ''),"ok 7\n";
 
 print +(defined($syms{$name}) ? 'not ' : ''),"ok 8\n";
 
-$obj = new VMS::DCLsym 'GLOBAL';
+my $obj = new VMS::DCLsym 'GLOBAL';
 print +($obj ? '' : 'not '),"ok 9\n";
 
 print +($obj->clearcache(0) ? '' : 'not '),"ok 10\n";
@@ -33,6 +34,7 @@ print +($obj->clearcache(1) ? 'not ' : ''),"ok 11\n";
 
 print +($obj->setsym($name,'Another_test') ? '' : 'not '),"ok 12\n";
 
+my ($tab);
 ($val,$tab) = $obj->getsym($name);
 print +($val eq 'Another_test' && $tab eq 'GLOBAL' ? '' : 'not '),"ok 13\n";
 
@@ -45,7 +47,7 @@ print +(defined($val) || defined($tab) ? 'not ' : ''),"ok 16\n";
 ($val) = `Show Symbol/Global $name` =~ /==\s+"(\w+)"$/;
 print +(defined($val) ? 'not ' : ''),"ok 17\n";
 
-tie %gsyms, VMS::DCLsym, 'GLOBAL' or die "not ok 18\n";
+tie my %gsyms, 'VMS::DCLsym', 'GLOBAL' or die "not ok 18\n";
 print "ok 18\n";
 
 print +(tied(%gsyms) =~ /^VMS::DCLsym/ ? '' : 'not '),"ok 19\n";

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -12,13 +12,16 @@
 
 use Config;
 use strict;
+use warnings;
+use feature 'state';
 
 eval { require POSIX; import POSIX 'locale_h'; };
 my $has_locale_h = ! $@;
 
 my @known_categories = ( qw(LC_ALL LC_COLLATE LC_CTYPE LC_MESSAGES LC_MONETARY
                             LC_NUMERIC LC_TIME LC_ADDRESS LC_IDENTIFICATION
-                            LC_MEASUREMENT LC_PAPER LC_TELEPHONE));
+                            LC_MEASUREMENT LC_PAPER LC_TELEPHONE LC_SYNTAX
+                            LC_TOD));
 my @platform_categories;
 
 # LC_ALL can be -1 on some platforms.  And, in fact the implementors could
@@ -186,26 +189,35 @@ sub valid_locale_categories() {
 }
 
 sub locales_enabled(;$) {
-    # Returns 0 if no locale handling is available on this platform; otherwise
-    # 1.
+    # If no parameter is specified, the function returns 1 if there is any
+    # "safe" locale handling available to the caller; otherwise 0.  Safeness
+    # is defined here as the caller operating in the main thread of a program,
+    # or if threaded locales are safe on the platform and Configured to be
+    # used.  This sub is used for testing purposes, and for those, this
+    # definition of safety is sufficient, and necessary to get some tests to
+    # run on certain configurations on certain platforms.  But beware that the
+    # main thread can change the locale of any subthreads unless
+    # ${^SAFE_LOCALES} is non-zero.
     #
-    # The optional parameter is a reference to a list of individual POSIX
-    # locale categories.  If any of the individual categories specified by the
-    # optional parameter is all digits (and an optional leading minus), it is
-    # taken to be the C enum for the category (e.g., &POSIX::LC_CTYPE).
-    # Otherwise it should be a string name of the category, like 'LC_TIME'.
-    # The initial 'LC_' is optional.  It is a fatal error to call this with
-    # something that isn't a known category to this file.
+    # Use the optional parameter to discover if a particular category or
+    # categories are available on the system.  1 is returned if the global
+    # criteria described in the previous paragraph are true, AND if all the
+    # specified categories are available on the platform and Configured to be
+    # used.  Otherwise 0 is returned.  The parameter is either a single POSIX
+    # locale category or a reference to a list of them.  Each category must be
+    # its name as a string, like 'LC_TIME' (the initial 'LC_' is optional), or
+    # the number this platform uses to signify the category (e.g.,
+    # 'locales_enabled(&POSIX::LC_CTYPE)'
     #
-    # This optional parameter denotes which POSIX locale categories must be
-    # available on the platform.  If any aren't available, this function
-    # returns 0; otherwise it returns 1 and changes the list for the caller so
-    # that any category names are converted into their equivalent numbers, and
-    # sorts it to match the expectations of _trylocale.
+    # When the function returns 1 and a parameter was specified as a list
+    # reference, the reference will be altered on return to point to an
+    # equivalent list such that  the categories are numeric instead of strings
+    # and sorted to meet the input expectations of _trylocale().
     #
-    # It is acceptable for the second parameter to be just a simple scalar
-    # denoting a single category (either name or number).  No conversion into
-    # a number is done in this case.
+    # It is a fatal error to call this with something that isn't a known
+    # category to this file.  If this happens, look first for a typo, and
+    # second if you are using a category unknown to Perl.  In the latter case
+    # a bug report should be submitted.
 
     # khw cargo-culted the '?' in the pattern on the next line.
     return 0 if $Config{ccflags} =~ /\bD?NO_LOCALE\b/;
@@ -214,6 +226,15 @@ sub locales_enabled(;$) {
     # normally would be available
     return 0 if ! defined &DynaLoader::boot_DynaLoader;
 
+    # Don't test locales where they aren't safe.  On systems with unsafe
+    # threads, for the purposes of testing, we consider the main thread safe,
+    # and all other threads unsafe.
+    if (! ${^SAFE_LOCALES}) {
+        require threads;
+        return 0 if threads->tid() != 0;
+    }
+
+    # If no setlocale, we need the POSIX 2008 alternatives
     if (! $Config{d_setlocale}) {
         return 0 if $Config{ccflags} =~ /\bD?NO_POSIX_2008_LOCALE\b/;
         return 0 unless $Config{d_newlocale};
@@ -225,7 +246,7 @@ sub locales_enabled(;$) {
     # Done with the global possibilities.  Now check if any passed in category
     # is disabled.
 
-    my $categories_ref = shift;
+    my $categories_ref = $_[0];
     my $return_categories_numbers = 0;
     my @categories_numbers;
     my $has_LC_ALL = 0;
@@ -234,9 +255,14 @@ sub locales_enabled(;$) {
     if (defined $categories_ref) {
         my @local_categories_copy;
 
-        if (ref $categories_ref) {
-            @local_categories_copy = @$$categories_ref;
+        my $reftype = ref $categories_ref;
+        if ($reftype eq 'ARRAY') {
+            @local_categories_copy = @$categories_ref;
             $return_categories_numbers = 1;
+        }
+        elsif ($reftype ne "") {
+            die "Parameter to locales_enabled() must be an ARRAY;"
+              . " instead you used a $reftype";
         }
         else {  # Single category passed in
             @local_categories_copy = $categories_ref;
@@ -296,7 +322,8 @@ sub locales_enabled(;$) {
         if ($has_LC_ALL) {
             push @categories_numbers, $category_number{'ALL'};
         }
-        $$categories_ref = \@categories_numbers;
+
+        @$categories_ref = @categories_numbers;
     }
 
     return 1;
@@ -315,11 +342,11 @@ sub find_locales ($;$) {
     # multiple) for all of them.  Each category can be a name (like 'LC_ALL'
     # or simply 'ALL') or the C enum value for the category.
 
-    my $categories = shift;
+    my $input_categories = shift;
     my $allow_incompatible = shift // 0;
 
-    $categories = [ $categories ] unless ref $categories;
-    return unless locales_enabled(\$categories);
+    my @categories = (ref $input_categories) ? $input_categories->@* : $input_categories;
+    return unless locales_enabled(\@categories);
 
     # Note, the subroutine call above converts the $categories into a form
     # suitable for _trylocale().
@@ -337,11 +364,11 @@ sub find_locales ($;$) {
     return if ($^O =~ /^uwin/);
 
     my @Locale;
-    _trylocale("C", $categories, \@Locale, $allow_incompatible);
-    _trylocale("POSIX", $categories, \@Locale, $allow_incompatible);
+    _trylocale("C", \@categories, \@Locale, $allow_incompatible);
+    _trylocale("POSIX", \@categories, \@Locale, $allow_incompatible);
 
     if ($Config{d_has_C_UTF8} && $Config{d_has_C_UTF8} eq 'true') {
-        _trylocale("C.UTF-8", $categories, \@Locale, $allow_incompatible);
+        _trylocale("C.UTF-8", \@categories, \@Locale, $allow_incompatible);
     }
 
     # There's no point in looking at anything more if we know that setlocale
@@ -349,13 +376,13 @@ sub find_locales ($;$) {
     return sort @Locale if defined $Config{d_setlocale_accepts_any_locale_name};
 
     foreach (1..16) {
-        _trylocale("ISO8859-$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("iso8859$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("iso8859-$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("iso_8859_$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("isolatin$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("isolatin-$_", $categories, \@Locale, $allow_incompatible);
-        _trylocale("iso_latin_$_", $categories, \@Locale, $allow_incompatible);
+        _trylocale("ISO8859-$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("iso8859$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("iso8859-$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("iso_8859_$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("isolatin$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("isolatin-$_", \@categories, \@Locale, $allow_incompatible);
+        _trylocale("iso_latin_$_", \@categories, \@Locale, $allow_incompatible);
     }
 
     # Sanitize the environment so that we can run the external 'locale'
@@ -376,7 +403,7 @@ sub find_locales ($;$) {
             # locales will cause all IO hadles to default to (assume) utf8
             next unless utf8::valid($_);
             chomp;
-            _trylocale($_, $categories, \@Locale, $allow_incompatible);
+            _trylocale($_, \@categories, \@Locale, $allow_incompatible);
         }
         close(LOCALES);
     } elsif ($^O eq 'VMS'
@@ -388,7 +415,7 @@ sub find_locales ($;$) {
         opendir(LOCALES, "SYS\$I18N_LOCALE:");
         while ($_ = readdir(LOCALES)) {
             chomp;
-            _trylocale($_, $categories, \@Locale, $allow_incompatible);
+            _trylocale($_, \@categories, \@Locale, $allow_incompatible);
         }
         close(LOCALES);
     } elsif (($^O eq 'openbsd' || $^O eq 'bitrig' ) && -e '/usr/share/locale') {
@@ -400,7 +427,7 @@ sub find_locales ($;$) {
         opendir(LOCALES, '/usr/share/locale');
         while ($_ = readdir(LOCALES)) {
             chomp;
-            _trylocale($_, $categories, \@Locale, $allow_incompatible);
+            _trylocale($_, \@categories, \@Locale, $allow_incompatible);
         }
         close(LOCALES);
     } else { # Final fallback.  Try our list of locales hard-coded here
@@ -421,7 +448,8 @@ sub find_locales ($;$) {
         }
 
         # The rest of the locales are in this file.
-        push @Data, <DATA>; close DATA;
+        state @my_data = <DATA>; close DATA if fileno DATA;
+        push @Data, @my_data;
 
         foreach my $line (@Data) {
             chomp $line;
@@ -431,30 +459,30 @@ sub find_locales ($;$) {
                                                      unless defined $locale_name;
             my @enc = _decode_encodings($encodings);
             foreach my $loc (split(/ /, $locale_name)) {
-                _trylocale($loc, $categories, \@Locale, $allow_incompatible);
+                _trylocale($loc, \@categories, \@Locale, $allow_incompatible);
                 foreach my $enc (@enc) {
-                    _trylocale("$loc.$enc", $categories, \@Locale,
+                    _trylocale("$loc.$enc", \@categories, \@Locale,
                                                             $allow_incompatible);
                 }
                 $loc = lc $loc;
                 foreach my $enc (@enc) {
-                    _trylocale("$loc.$enc", $categories, \@Locale,
+                    _trylocale("$loc.$enc", \@categories, \@Locale,
                                                             $allow_incompatible);
                 }
             }
             foreach my $lang (split(/ /, $language_codes)) {
-                _trylocale($lang, $categories, \@Locale, $allow_incompatible);
+                _trylocale($lang, \@categories, \@Locale, $allow_incompatible);
                 foreach my $country (split(/ /, $country_codes)) {
                     my $lc = "${lang}_${country}";
-                    _trylocale($lc, $categories, \@Locale, $allow_incompatible);
+                    _trylocale($lc, \@categories, \@Locale, $allow_incompatible);
                     foreach my $enc (@enc) {
-                        _trylocale("$lc.$enc", $categories, \@Locale,
+                        _trylocale("$lc.$enc", \@categories, \@Locale,
                                                             $allow_incompatible);
                     }
                     my $lC = "${lang}_\U${country}";
-                    _trylocale($lC, $categories, \@Locale, $allow_incompatible);
+                    _trylocale($lC, \@categories, \@Locale, $allow_incompatible);
                     foreach my $enc (@enc) {
-                        _trylocale("$lC.$enc", $categories, \@Locale,
+                        _trylocale("$lC.$enc", \@categories, \@Locale,
                                                             $allow_incompatible);
                     }
                 }

--- a/t/loc_tools.pl
+++ b/t/loc_tools.pl
@@ -11,8 +11,6 @@
 # for this file, and are not to be used by outside callers.
 
 use Config;
-use strict;
-use warnings;
 use feature 'state';
 
 eval { require POSIX; import POSIX 'locale_h'; };


### PR DESCRIPTION
This p.r. is a bit of a grab-bag, but it basically completes work on warnings by default for the `ext/` directory, *i.e.,* for https://github.com/atoomic/perl/issues/305.

To clean up the remaining warnings in `ext/POSIX/t/posix.t`, we make some changes in that file as suggested in a Perl 5 issue and we pull in several recent commits to `t/loc_tools.pl` made in blead.

I also clean up some strictures-related warnings in one file that we can't run because it's VMS-specific.